### PR TITLE
fix: feat/kozuka/TinyLiDARNet/create_directory_Step1_terminal4

### DIFF
--- a/docs/ml_sample/develop_pilot_net.md
+++ b/docs/ml_sample/develop_pilot_net.md
@@ -91,7 +91,7 @@ cp -r /aichallenge/ml_workspace/rawdata/* /aichallenge/ml_workspace/train
 ```
 
 ```sh
-mkdir -p /aichallenge/ml_workspace/val # if there are no train directory
+mkdir -p /aichallenge/ml_workspace/val # if there are no val directory
 cp -r /aichallenge/ml_workspace/rawdata/* /aichallenge/ml_workspace/val
 ```
 

--- a/docs/ml_sample/develop_pilot_net.md
+++ b/docs/ml_sample/develop_pilot_net.md
@@ -86,10 +86,12 @@ cd /aichallenge/ml_workspace
 検証データを別に取るのが理想ですが、まずは動作を掴むために訓練・検証ともに同じデータを使います:
 
 ```sh
+mkdir -p /aichallenge/ml_workspace/train # if there are no train directory
 cp -r /aichallenge/ml_workspace/rawdata/* /aichallenge/ml_workspace/train
 ```
 
 ```sh
+mkdir -p /aichallenge/ml_workspace/val # if there are no train directory
 cp -r /aichallenge/ml_workspace/rawdata/* /aichallenge/ml_workspace/val
 ```
 

--- a/docs/ml_sample/develop_tiny_lidar_net.md
+++ b/docs/ml_sample/develop_tiny_lidar_net.md
@@ -95,11 +95,13 @@ cd ml_workspace
 本当は訓練と検証データを別のものにする、データを選定するなどの工夫をすべきですが、一旦流れを掴むために訓練データと検証データに取得したデータを下記のコマンドでそのままいれてしまいます。
 
 ```sh
+mkdir -p /aichallenge/ml_workspace/train # if there are no train directory
 cp -r /aichallenge/ml_workspace/rawdata/* /aichallenge/ml_workspace/train
 ```
 
 ```sh
-cp -r  /aichallenge/ml_workspace/rawdata/* /aichallenge/ml_workspace/val
+mkdir -p /aichallenge/ml_workspace/val # if there are no val directory
+cp -r /aichallenge/ml_workspace/rawdata/* /aichallenge/ml_workspace/val
 ```
 
 <details>


### PR DESCRIPTION
fix: [horizontal expansion (横展開)][TinyLiDARNet] write train and val directory if there are no such dir