### PR TITLE
docs: update official site links and add intro video

### DIFF
--- a/docs/getting-started.ja.md
+++ b/docs/getting-started.ja.md
@@ -8,7 +8,7 @@
 
 ??? note  "1. 自動運転AIチャレンジへの参加登録"
 
-    今年度の大会の参加登録は[:material-launch: 参加登録フォーム](https://questant.jp/q/DNW53QLW){ .md-button .md-button--primary target="_blank" }から
+    今年度の大会の参加登録は[:material-launch: 参加登録フォーム](https://questant.jp/q/QUHU0GNO){ .md-button .md-button--primary target="_blank" }から
 
 ??? note  "2. オンライン採点環境へのアクセス"
 

--- a/docs/index.ja.md
+++ b/docs/index.ja.md
@@ -36,4 +36,4 @@ EVレーシングカートを使用した実車大会を開催します。シミ
 
     大会の日程などの詳細情報は公式サイトでご確認ください。
 
-    [:material-launch: 大会公式サイトを見る ](https://www.jsae.or.jp/jaaic2025/){ .md-button .md-button--primary target="_blank" }
+    [:material-launch: 大会公式サイトを見る ](https://www.jsae.or.jp/jaaic/){ .md-button .md-button--primary target="_blank" }

--- a/docs/setup/introduction.ja.md
+++ b/docs/setup/introduction.ja.md
@@ -6,6 +6,8 @@
       - `rocker` は GUI 転送用途に限定し、プロセス管理は docker compose を活用しています。
       - 個別セットアップ手順を廃止し、一括インストール手順に統一しました。
 
+<iframe width="960" height="540" src="https://www.youtube.com/embed/K_ToeWGitbk?si=Chop0CTjs0rx-itt" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+
 ## 環境構築
 
 curlのパッケージをinstallしましょう。


### PR DESCRIPTION
## 内容

- オフィシャルサイトと参加フォームへのリンクが2025年度のものだったため、2026年度に更新
- 導入動画を追加

## Tests

- [x] 参加登録フォームのリンク（getting-started ページ）をクリックし、正しいフォームページが開くことを確認
  - https://questant.jp/q/QUHU0GNO
- [x] 大会公式サイトのリンク（トップページ）をクリックし、正しいページが開くことを確認
- [x] セットアップ紹介ページで YouTube 動画が正常に表示・再生できることを確認
- [x] mkdocs build でエラー、新規警告が出ないことを確認
