### PR TITLE
docs: add simulator launch modes and E2E / S2R class modes

### DIFF
--- a/docs/development/commands.ja.md
+++ b/docs/development/commands.ja.md
@@ -42,6 +42,7 @@ Dockerイメージをビルドします。ビルドログは `output/docker/` �
 | `make dev2` | AWSIM + Autoware x 2 を開発用に起動します |
 | `make dev3` | AWSIM + Autoware x 3 を開発用に起動します |
 | `make dev4` | AWSIM + Autoware x 4 を開発用に起動します |
+| `make e2e` | AWSIM + Autoware を E2E 練習用に起動します（NPC 2台入り。提出前の確認もこれ） |
 | `make eval` | AWSIM + Autoware を評価用に起動します |
 | `make gate1` | 安全ゲートシナリオ（障害物停止）を起動します |
 | `make gate2` | 安全ゲートシナリオ（追い越し）を起動します |
@@ -60,12 +61,16 @@ Dockerイメージをビルドします。ビルドログは `output/docker/` �
 | `make simulator-dev2` | AWSIM のみ起動します (2台走行用) |
 | `make simulator-dev3` | AWSIM のみ起動します (3台走行用) |
 | `make simulator-dev4` | AWSIM のみ起動します (4台走行用) |
+| `make simulator-e2e-final` | AWSIM のみ起動します（E2E 決勝の設定） |
+| `make simulator-s2r-final` | AWSIM のみ起動します（S2R 決勝の設定） |
 | `make autoware-simulator` | Autoware のみ起動します（シミュレータ向け） |
 | `make autoware-vehicle` | Autoware のみ起動します（実車向け） |
 | `make driver` | 実車インターフェース（`racing_kart_interface`）を起動します |
 | `make zenoh` | Zenoh（実車遠隔接続）を起動します |
 | `make rviz2` | RViz2 を起動します |
 | `make autoware-driver-zenoh` | `driver` + `autoware` + `zenoh` をまとめて起動します（実車向け） |
+
+`make simulator-<モード名>` は `aichallenge/simulator_scripts/<モード名>.sh` を実行します。モードの一覧と設定値は[シミュレーターの起動モード](../specifications/simulator.ja.md#launch-modes)を参照してください。
 
 ### コマンド送信
 

--- a/docs/specifications/simulator.ja.md
+++ b/docs/specifications/simulator.ja.md
@@ -21,8 +21,8 @@
 | --- | --- | --- | --- |
 | `dev` | `make dev`（`dev2`〜`dev4` で複数台） | 開発 / S2R 練習 | 1台（引数で N 台）・周回/時間 無制限・カメラ/LiDAR off |
 | `e2e` | `make e2e` | E2E 練習（提出前の確認もこれ） | 1台 + NPC 2台・6周・タイムアウト実質なし・カメラ/LiDAR cpu |
-| `e2e-final` | `make simulator-e2e-final` | E2E 決勝 | 4台・6周・420秒・sync開始・ハンディキャップ/ランキング on |
-| `s2r-final` | `make simulator-s2r-final` | S2R 決勝 | 4台・6周・420秒・sync開始・ハンディキャップ/ランキング on |
+| `e2e-final` | `make simulator-e2e-final` | E2E 決勝 | 4台・6周・420秒・sync開始・ハンディキャップ/ランキング on・エンジン音 on |
+| `s2r-final` | `make simulator-s2r-final` | S2R 決勝 | 4台・6周・420秒・sync開始・ハンディキャップ/ランキング on・エンジン音 on |
 | `eval` | `make eval` | 評価（提出時と同じ条件） | 1台・6周・600秒・sync開始 |
 | `parallel` | `make simulator-parallel` | 複数台レース | 3台・6周・600秒・sync開始 |
 | `gate` | `make gate1`〜`make gate3` | セーフティゲートのテスト | 1台・シナリオ別 |
@@ -47,6 +47,7 @@
 - 練習モードは周回数・タイムアウトを無制限（`e2e` は `--timeout 10000000.0`、`dev` はさらに `--laps unlimited`）にしてあり、途中で止まらずに走り続けられます。時間制限つきで確認したい場合は決勝モードか `make eval` を使ってください。
 - 練習は `count` 開始（全車が接地してから自動でカウントダウン。`e2e` はカウント0秒で即スタート）、決勝は `sync` 開始（`/admin/awsim/start` を待って一斉スタート）です。
 - `e2e` は `--start-random on` で開始位置が毎回変わるため、特定のスタート位置に依存しない挙動を確認できます。決勝は公平性のため固定です。
+- エンジン音（`--sound`）は決勝の2モードのみ on です。練習モードや評価（`make eval`）では off にしてあります。
 
 ## 画面説明
 

--- a/docs/specifications/simulator.ja.md
+++ b/docs/specifications/simulator.ja.md
@@ -10,6 +10,44 @@
 
 `make dev` などでシミュレーターはAutowareと一緒に自動的に起動します。シミュレーターを単体で起動したい場合は `make simulator` を使用します。
 
+## 起動モード { #launch-modes }
+
+用途ごとに起動モードが用意されており、実体は `aichallenge/simulator_scripts/<モード名>.sh` です。**起動引数の正本は各スクリプト**なので、設定を変えたいときはこのファイルを直接編集してください。
+
+- `make simulator-<モード名>` … AWSIM のみ起動します（例: `make simulator-e2e-final`）
+- `make dev` / `make e2e` / `make eval` / `make gate1`〜`gate3` … AWSIM と Autoware をまとめて起動します
+
+| モード | 起動コマンド | 用途 | 主な設定 |
+| --- | --- | --- | --- |
+| `dev` | `make dev`（`dev2`〜`dev4` で複数台） | 開発 / S2R 練習 | 1台（引数で N 台）・周回/時間 無制限・カメラ/LiDAR off |
+| `e2e` | `make e2e` | E2E 練習（提出前の確認もこれ） | 1台 + NPC 2台・6周・タイムアウト実質なし・カメラ/LiDAR cpu |
+| `e2e-final` | `make simulator-e2e-final` | E2E 決勝 | 4台・6周・420秒・sync開始・ハンディキャップ/ランキング on |
+| `s2r-final` | `make simulator-s2r-final` | S2R 決勝 | 4台・6周・420秒・sync開始・ハンディキャップ/ランキング on |
+| `eval` | `make eval` | 評価（提出時と同じ条件） | 1台・6周・600秒・sync開始 |
+| `parallel` | `make simulator-parallel` | 複数台レース | 3台・6周・600秒・sync開始 |
+| `gate` | `make gate1`〜`make gate3` | セーフティゲートのテスト | 1台・シナリオ別 |
+| `multiplay-host` / `multiplay-client` | `make simulator-multiplay-host` など | 通信対戦（[Multiplay](../development/multiplay.ja.md)） | - |
+| `simulator`（既定） | `make simulator` | 引数なしの素起動 | 起動時UIで設定を選択 |
+
+### 部門ごとのモード（E2E / S2R） { #class-modes }
+
+部門ごとに **練習 → 決勝** の2モードがあり、違いはセンサー構成と、車両数・ハンディキャップ・ランキングだけです。
+
+| | E2E 部門 | S2R 部門 |
+| --- | --- | --- |
+| 課題 | End-to-End（カメラ・LiDAR から直接制御） | Sim-to-Real（実車移行を前提） |
+| カメラ / LiDAR | `cpu`（有効） | `off` |
+| IMU / GNSS / V2X | `off`（明示的に無効化） | 有効 |
+| 練習 | `e2e` | `dev` |
+| 決勝 | `e2e-final` | `s2r-final` |
+
+- センサーの on/off がそのまま部門の違いです。E2E 部門ではカメラ・LiDAR 以外の情報を使わないため、`e2e.sh` / `e2e-final.sh` では `--imu off --gnss off --v2x off` を明示しています。
+- **S2R の練習には `dev` をそのまま使います**。練習に必要な条件（カメラ・LiDAR off、ハンディキャップ・ランキング off、無制限走行）を `dev` が満たしているため、S2R 専用の練習モードはありません。
+- **E2E の練習と提出前の確認も `e2e` の1モードにまとめています**。提出物の評価そのものは `make eval`（`eval` モード）と同じ条件で行われます。
+- 練習モードは周回数・タイムアウトを無制限（`e2e` は `--timeout 10000000.0`、`dev` はさらに `--laps unlimited`）にしてあり、途中で止まらずに走り続けられます。時間制限つきで確認したい場合は決勝モードか `make eval` を使ってください。
+- 練習は `count` 開始（全車が接地してから自動でカウントダウン。`e2e` はカウント0秒で即スタート）、決勝は `sync` 開始（`/admin/awsim/start` を待って一斉スタート）です。
+- `e2e` は `--start-random on` で開始位置が毎回変わるため、特定のスタート位置に依存しない挙動を確認できます。決勝は公平性のため固定です。
+
 ## 画面説明
 
 `make simulator` で起動した場合、設定画面が表示されます。後述の起動オプション相当の設定をGUIで行うことが可能です。設定が出来たら「Start」をクリックします。
@@ -44,6 +82,8 @@ AWSIMはコマンドライン引数で動作を制御でき、起動スクリプ
 | --collisions  | bool   | false      | 車両同士の衝突判定の有効/無効を設定します。       |
 | --wall-recovery | bool | true       | 壁リカバリー機能の有効/無効を設定します。         |
 | --ranking     | bool   | false      | ランキング表示の有効/無効を設定します。           |
+| --handicap    | bool   | false      | 順位に応じたハンディキャップの有効/無効を設定します。 |
+| --start-random | bool  | false      | 開始位置のランダム化の有効/無効を設定します。     |
 
 ### 制御・入力設定
 
@@ -60,6 +100,9 @@ AWSIMはコマンドライン引数で動作を制御でき、起動スクリプ
 | ---------- | ---- | ---------- | --------------------------------------- |
 | --camera   | off/cpu/gpu | gpu | カメラセンサ。`gpu`/`cpu` で有効化、`off` で無効化します。 |
 | --lidar    | off/cpu/gpu | cpu | LiDARセンサ。`gpu`/`cpu` で有効化、`off` で無効化します。 |
+| --imu      | bool | on | IMU（`/sensing/imu/imu_raw`）の有効/無効を設定します。 |
+| --gnss     | bool | on | GNSS（`/sensing/gnss/nav_sat_fix`）の有効/無効を設定します。`off` の車両は `/v2x/vehicle_positions` からも消えます。 |
+| --v2x      | bool | on | V2X車両位置共有（`/v2x/vehicle_positions`）の有効/無効を設定します。 |
 | -headless  | フラグ | （未指定） | Unity標準のヘッドレス起動フラグ（シングルダッシュ）。指定するとカメラ・LiDARセンサを無効化し、描画なしで軽量に実行します。 |
 
 ### シナリオ・リプレイ


### PR DESCRIPTION
## Summary

シミュレーターの**起動モード**と、**部門ごと（E2E / S2R）のモードの使い分け**をドキュメントに追加します。aichallenge-racingkart 側の [PR #274](https://github.com/AutomotiveAIChallenge/aichallenge-racingkart/pull/274) に対応する内容です。今回は日本語ページのみ更新しています。

### 仕様 > シミュレーター（`specifications/simulator.ja.md`）

- 「起動モード」節を追加。`make simulator-<モード名>` = `aichallenge/simulator_scripts/<モード名>.sh` であること、起動引数の正本は各スクリプトであることを明記し、モード一覧（`dev` / `e2e` / `e2e-final` / `s2r-final` / `eval` / `parallel` / `gate` / `multiplay-*` / `simulator`）を表にしました。
- 「部門ごとのモード（E2E / S2R）」節を追加。
    - 部門の違いはセンサー構成（E2E はカメラ・LiDAR 有効 + IMU/GNSS/V2X 無効、S2R はその逆）。
    - **E2E の練習と提出前の確認は `e2e` の1モード**（NPC 2台入り）。評価そのものは `make eval` と同じ条件。
    - **S2R の練習は `dev` をそのまま使う**（専用の練習モードはなし）。S2R 系のスクリプトは決勝用のみ。
    - 練習は無制限走行 + count 開始、決勝は 420秒 + sync 開始という違いも記載。
- 起動オプション表に、上記の説明で参照している `--handicap` / `--start-random` / `--imu` / `--gnss` / `--v2x` を追記（既定値は AWSIM の CLI 仕様に準拠）。

### 開発 > コマンド一覧（`development/commands.ja.md`）

- `make e2e` / `make simulator-e2e-final` / `make simulator-s2r-final` を追加。
- `make simulator-<モード名>` の説明と、起動モード節へのリンクを追加。

## Test plan

- [x] `mkdocs build` が通ること（新規の警告なし。既存の警告のみ）
- [x] 生成 HTML に `id="launch-modes"` / `id="class-modes"` が出力され、コマンド一覧からのリンクが `simulator.html#launch-modes` で解決されること
- [ ] `mkdocs serve` で表示崩れがないことを目視確認
