### PR TITLE
docs(specifications): note that --overtaking-lane is only on the racingkart dev branch

### DIFF
--- a/docs/faq.ja.md
+++ b/docs/faq.ja.md
@@ -189,7 +189,7 @@
     HUD の速度表示の横に `BLOCK` と残り秒数が表示されます。また、AWSIM のログに `OvertakingLane: BLOCK fired ...` が出力され、走行結果（`result-summary.json`）の `penalty_events` / `penalty_by_kind` にも `block` として記録されます。
 
 ??? question "ローカルで練習するにはどうすればよいですか？"
-    `make simulator-s2r-final` で AWSIM を起動し、別ターミナルで `make autoware-simulator` を実行すると、SIM決勝と同じ条件（オーバーテイクレーン on）で走行できます。`make dev` で試したい場合は `dev.sh` の `--overtaking-lane off` を `on` に書き換えてください。詳細は[シミュレータ仕様](./specifications/simulator.ja.md#launch-modes)を参照してください。
+    `make simulator-s2r-final` で AWSIM を起動し、別ターミナルで `make autoware-simulator` を実行すると、SIM決勝と同じ条件（オーバーテイクレーン on）で走行できます（`s2r-final.sh` に `--overtaking-lane on` が含まれている必要があります。2026年9月12日時点では aichallenge-racingkart の `dev` ブランチのみ）。`make dev` で試したい場合は `dev.sh` の `--overtaking-lane off` を `on` に書き換えてください。詳細は[シミュレータ仕様](./specifications/simulator.ja.md#launch-modes)を参照してください。
 
 ## 解決しない場合
 

--- a/docs/setup/introduction.en.md
+++ b/docs/setup/introduction.en.md
@@ -93,6 +93,13 @@ The following describes what `setup.bash` performs interactively, step by step. 
     cd ~/aichallenge-racingkart
     ```
 
+    The finals PC uses the `main` branch. Overtaking-lane practice (`--overtaking-lane`) requires the `dev` branch, so switch to it if you want to practice that:
+
+    ```bash
+    git -C ~/aichallenge-racingkart fetch origin dev
+    git -C ~/aichallenge-racingkart checkout dev
+    ```
+
 ??? note "6. :material-security: Verify repository"
     Checks that the repository exists correctly.
 

--- a/docs/setup/introduction.en.md
+++ b/docs/setup/introduction.en.md
@@ -89,7 +89,7 @@ The following describes what `setup.bash` performs interactively, step by step. 
 
     ```bash
     cd ~
-    git clone https://github.com/AutomotiveAIChallenge/aichallenge-racingkart.git
+    git clone -b main https://github.com/AutomotiveAIChallenge/aichallenge-racingkart.git
     cd ~/aichallenge-racingkart
     ```
 

--- a/docs/setup/introduction.ja.md
+++ b/docs/setup/introduction.ja.md
@@ -89,7 +89,7 @@ curl -fsSL "https://raw.githubusercontent.com/AutomotiveAIChallenge/aichallenge-
 
     ```bash
     cd ~
-    git clone https://github.com/AutomotiveAIChallenge/aichallenge-racingkart.git
+    git clone -b main https://github.com/AutomotiveAIChallenge/aichallenge-racingkart.git
     cd ~/aichallenge-racingkart
     ```
 

--- a/docs/setup/introduction.ja.md
+++ b/docs/setup/introduction.ja.md
@@ -93,6 +93,15 @@ curl -fsSL "https://raw.githubusercontent.com/AutomotiveAIChallenge/aichallenge-
     cd ~/aichallenge-racingkart
     ```
 
+    決勝PCは `main` ブランチを使用します。オーバーテイクレーンの練習（`--overtaking-lane`）には `dev` ブランチが必要なので、練習したい場合は以下で切り替えてください。
+
+    ```bash
+    git -C ~/aichallenge-racingkart fetch origin dev
+    git -C ~/aichallenge-racingkart checkout dev
+    ```
+
+    詳細は[シミュレータ仕様](../specifications/simulator.ja.md#launch-modes)を参照してください。
+
 ??? note "6. :material-security: repositoryの確認"
     ちゃんとレポジトリが存在しているかチェック
 

--- a/docs/specifications/simulator.ja.md
+++ b/docs/specifications/simulator.ja.md
@@ -50,6 +50,9 @@
 - エンジン音（`--sound`）は決勝の2モードのみ on です。練習モードや評価（`make eval`）では off にしてあります。
 - **オーバーテイクレーン（`--overtaking-lane`）は `s2r-final` のみ on** です。[ルール](../competition/sw-class.ja.md#overtake-lane)と同じ条件で練習する場合は `make simulator-s2r-final` で AWSIM を起動し、別ターミナルで `make autoware-simulator` を実行します。`make dev` で判定を試したい場合は `dev.sh` の `--overtaking-lane off` を `on` に書き換えてください。
 
+!!! warning "`--overtaking-lane` は aichallenge-racingkart の `dev` ブランチにのみ入っています（2026年9月12日時点）"
+    `--overtaking-lane` フラグは aichallenge-racingkart [#295](https://github.com/AutomotiveAIChallenge/aichallenge-racingkart/pull/295) で `dev` ブランチに追加されました。`setup.bash` が既定で取得する `main` ブランチ（2026年8月24日の `0c249d5`）の `s2r-final.sh` / `dev.sh` にはまだ含まれていないため、`main` のまま `make simulator-s2r-final` を実行してもオーバーテイクレーンは有効になりません。手元のブランチは `git -C ~/aichallenge-racingkart branch --show-current` で、フラグの有無は `grep -- --overtaking-lane ~/aichallenge-racingkart/aichallenge/simulator_scripts/s2r-final.sh` で確認できます。
+
 ## 画面説明
 
 `make simulator` で起動した場合、設定画面が表示されます。後述の起動オプション相当の設定をGUIで行うことが可能です。設定が出来たら「Start」をクリックします。


### PR DESCRIPTION
## 概要
シミュレーター仕様と FAQ では「`make simulator-s2r-final` でオーバーテイクレーン on の練習ができる」と案内していますが、`--overtaking-lane` は aichallenge-racingkart #295 で `dev` に入ったのみで、`setup.bash` が取得する `main`（2026-08-24 の `0c249d5`）の `s2r-final.sh` には含まれていません。`main` で練習しているチームは BLOCK 判定を一度も体験できません。

- 仕様ページと FAQ に、ブランチの条件と確認コマンドを追記
- 手動 clone の手順を `git clone -b main` にして、`setup.bash`（既定 main）・SIM決勝 PC（main）と揃えました（現在は GitHub の既定ブランチ `dev` が取得されます）

確認（2026-09-12）:
```bash
R=AutomotiveAIChallenge/aichallenge-racingkart
gh api "repos/$R/contents/aichallenge/simulator_scripts/s2r-final.sh?ref=main" --jq .content | base64 -d | grep -c overtaking   # 0
gh api "repos/$R/compare/main...dev" --jq .ahead_by                                                                           # 13
```
`mkdocs build` の WARNING 数は変更前後とも 19 で、新規の警告はありません。

**運営の皆さまへ:** 9/18 の準備日までに #295 を `main` へ反映いただければ、この注意書きは削除できます。

## Summary
The simulator spec and FAQ say teams can practise with the overtaking lane on via `make simulator-s2r-final`, but `--overtaking-lane` only exists on `dev` (aichallenge-racingkart #295). `s2r-final.sh` on `main` (`0c249d5`, 2026-08-24), which `setup.bash` installs, does not have it, so a team practising on `main` never sees a BLOCK.

- Adds the branch requirement and two check commands to the spec page and the FAQ.
- Makes the manual clone step `git clone -b main`, matching `setup.bash` (default `main`) and the SIM-finals PC (`main`). A plain clone currently gets the GitHub default branch, `dev`.

`mkdocs build` gives 19 warnings before and after; no new warnings.

**For the organisers:** if #295 is merged into `main` before the 9/18 prep day, this warning can simply be removed.

---
Team Hayes (Ajayaditya Lokchandra, Nithisha Venkatesh)

本PRはAIコーディング支援を用いて作成し、上記の確認手順で検証しました。 / Prepared with AI coding assistance and verified with the checks above.
