### PR TITLE
docs(competition): resync sw-class.en.md with the current Japanese rules

### DIFF
--- a/.markdown-link-check.json
+++ b/.markdown-link-check.json
@@ -33,6 +33,9 @@
     },
     {
       "pattern": "^#byod$"
+    },
+    {
+      "pattern": "^#prohibited$"
     }
   ]
 }

--- a/docs/competition/sw-class.en.md
+++ b/docs/competition/sw-class.en.md
@@ -1,36 +1,83 @@
-# SW Division Rules
+# Sim to Real Division Rules
 
-## SW Division Overview
+!!! warning "WIP"
+    Some rules are not yet finalized and may be updated.
 
-The SW Division progresses from qualifying to finals as follows:
+## Sim to Real Division Overview
+
+The Sim to Real SW Division progresses from qualifying to the finals as follows.
 
 | Item | Schedule | Content | Participating Teams |
 | --- | --- | --- | --- |
-| SW Division SIM Qualifying | July 1 – September 1 | Race in online simulation environment | All participating teams |
-| SW Division SIM Finals | September 19 | Race in simulation environment at the finals venue | Top 32 teams from SIM Qualifying |
-| SW Division Real Vehicle Finals | September 20 | Real vehicle race at City Circuit Tokyo Bay (CCTB) | Top 8–16 teams from SIM Finals |
+| Sim to Real Division SIM Qualifying | July 1 – September 1 | Race in the online simulation environment | All participating teams |
+| SIM Finals Preparation | September 18 | Operation check and practice runs in the same environment as on the SIM Finals day | Teams among the top 32 of SIM Qualifying that wish to take part |
+| Sim to Real Division SIM Finals | September 19 | Race in the simulation environment at the finals venue | Top 32 teams from SIM Qualifying |
+| Sim to Real Division Real Vehicle Finals | September 20 | Real vehicle race at City Circuit Tokyo Bay (CCTB) | Top 16 teams from the SIM Finals |
 
-## Common Rules for SW Division
+## Common Rules for the Sim to Real Division
 
 ### Race Format
 
-- In SIM Qualifying and SIM Finals, vehicles race in a simulated CCTB course environment on AWSIM. In the Real Vehicle Finals, vehicles race at the actual CCTB.
-- Races are held with 3–4 vehicles simultaneously.
-- The race is 6 laps, and finishing order determines the ranking.
-- The time limit is 10 minutes. (TBD)
-- Starting positions are random or determined by past performance. (TBD)
+- In SIM Qualifying and the SIM Finals, vehicles race on AWSIM in an environment that replicates the City Circuit Tokyo Bay (CCTB) course. In the Real Vehicle Finals, real karts race on site at CCTB.
+- Races are held with 3–4 vehicles running simultaneously.
+- Starting positions are determined by past results.
 
 !!! info "Changes from previous competitions"
-    Previously, competition used a time attack format. Starting this year, competition uses a race format where finishing order among multiple simultaneous vehicles determines ranking. Skills in overtaking other vehicles are now required, not just driving fast.
+    Previous competitions used a time attack format. From this year, the competition uses a race format with multiple vehicles running simultaneously. Driving fast is not enough; the ability to overtake other vehicles is also required. In addition, in the Real Vehicle Finals, not only speed but also having few collisions is evaluated.
 
 ### Speed and Penalties
 
-- Acceleration limit is approximately 1.0 m/s².
-- Speed limit follows the physics model used by the simulator. For real vehicles, the speed is limited to 30 km/h.
-- Handicaps may be applied to acceleration and speed based on race position.
-- If a collision with course walls or other vehicles occurs, or if invalid acceleration is input, the vehicle's speed will be restricted for a certain time as a penalty.
-- Boost items that temporarily increase acceleration are available. (SIM environment only, planned)
-- When colliding with a wall, automatic attitude correction is performed. However, this does not 100% prevent the vehicle from becoming stuck after a wall collision. (SIM environment only)
+- The acceleration limit is approximately 1.0 m/s². (Breakdown: acceleration limit 1.37, rolling resistance 0.37)
+- The speed limit follows the physics model used by the simulator. On the real vehicle, speed is limited to about 25 km/h.
+- Depending on the in-race position, a handicap may be applied to acceleration and speed. (SIM environment only)
+- When one of the following penalties is incurred, speed is limited to **5 km/h** for a fixed period. The type is the name shown on the HUD and in the race result. (SIM environment only)
+    - Penalties exist to prevent driving that falls under the [Prohibited Actions](#prohibited).
+    - The length of the speed limit is proportional to the danger. Driving that obstructs other vehicles is penalized the longest, and over-acceleration, which only affects your own vehicle, the shortest.
+
+| Type | Condition | Speed limit |
+| --- | --- | --- |
+| `CRASH` | Your front bumper touches another vehicle's rear bumper. While reversing, contact between your rear bumper and another vehicle's front bumper also triggers it | 10 seconds |
+| `WALL` | Contact with a wall. Contact between vehicles is treated as `CRASH` and is not counted as `WALL` | 5 seconds |
+| `OVER` | Over-acceleration. The acceleration input before clamping exceeds **3 m/s²**, or the input rate is **250 Hz** or higher | 2 seconds |
+| `BLOCK` | Overtaking lane violation (see below) | 20 seconds |
+
+In a rear-end collision, the vehicle that hits is penalized; the vehicle that is hit is not exempt. While contact continues, the `CRASH` limit time keeps being renewed.
+
+If a vehicle that is reversing collides with a vehicle behind it, **the reversing vehicle (the one in front) also receives `CRASH`**. Because contact between your rear bumper and another vehicle's front bumper triggers it, both the reversing vehicle and the vehicle behind that it hit are penalized. When reversing, for example to return to the course, wait until the vehicles behind have passed before moving.
+
+When a penalty is triggered, its type is shown in red next to the speed display on the HUD, and speed drops to 5 km/h.
+
+??? example "HUD display examples"
+    ![penalty_crash](../assets/penalty_crash.png)
+
+    `CRASH` triggered after rear-ending the vehicle ahead.
+
+    ![penalty_wall](../assets/penalty_wall.png)
+
+    `WALL` triggered after touching a wall.
+
+- A boost item that temporarily increases acceleration is available. (SIM environment only)
+
+#### Overtaking Lane { #overtake-lane }
+
+In the SIM Finals, to discourage driving that blocks the path of vehicles behind, designated sections of the course are defined as an **overtaking lane**. AWSIM judges this automatically. (SIM Finals only. Not applied to the End to End Division.)
+
+??? info "Detailed rules and appearance"
+    - The overtaking lane is drawn on the road surface as a **light-blue rectangle**.
+    - A vehicle whose entire body is inside the overtaking lane and that is running at **27 km/h or faster** is an **attacker**. While an attacker is present, the overtaking lane pulses orange.
+    - While an attacker is present, any other vehicle touching the overtaking lane at **27 km/h or slower** commits a violation unless it has fully left the lane within **3 seconds**. Accelerating does not remove the obligation to leave.
+    - While an attacker is present, a vehicle outside the overtaking lane that touches it at **less than 27 km/h** also commits a violation.
+    - A vehicle that commits a violation receives a `BLOCK` penalty (**speed limited to 5 km/h for 20 seconds**). The HUD shows `BLOCK` and the remaining seconds.
+
+    ![overtake_lane_normal](../assets/overtake_lane_normal.png)
+
+    The normal state. The light-blue area of the road surface is the overtaking lane.
+
+    ![overtake_lane_active](../assets/overtake_lane_active.png)
+
+    While a vehicle at 27 km/h or faster is inside the overtaking lane, the lane turns orange.
+
+There are no restrictions if you do not enter the overtaking lane. To practice under the same conditions, start AWSIM with `make simulator-s2r-final` and run `make autoware-simulator` in another terminal (see also the [Simulator specifications](../specifications/simulator.en.md)). Frequently asked questions are collected in the [FAQ (Japanese)](https://automotiveaichallenge.github.io/aichallenge-documentation-racingkart/faq.html#overtake-lane).
 
 ### Available Sensors
 
@@ -38,74 +85,145 @@ The SW Division progresses from qualifying to finals as follows:
 - GNSS
 - Steer Angle
 - Wheel Odometry
-- V2X information (position of other vehicles)
+- Gear Status
+- V2X information (positions of other vehicles)
 
-### Safety Gates
+### Safety Gates { #safety-gate }
 
-Clearing all of the following safety gates is strongly recommended (not mandatory):
+Clearing all of the following safety gates is strongly recommended. It is not mandatory, but to win races with multiple vehicles it is important that your vehicle can drive while clearing these safety gates. They can be run locally with `make gate1` (obstacle stop), `make gate2` (overtaking) and `make gate3` (lane keeping); see the [Development Guide](../development/development-guide.en.md).
 
 - Obstacle stop
 - NPC overtaking
 - Lane keeping
 
-### Prohibited Actions
+### Prohibited Actions { #prohibited }
 
 The following actions and code are prohibited.
 Code checks will be performed from the Finals onwards.
 
 - Intentionally driving in a dangerous manner.
-- Hacking the simulation environment itself. (e.g., intercepting communications of other vehicles or injecting false data)
+- Intentionally weaving or driving in a way that obstructs other vehicles.
+- Using information about vehicles behind you obtained via V2X to obstruct their path. This includes squeezing, weaving and unnecessary deceleration. Referring to information about vehicles behind for safety checks, for example when returning to the course in reverse, is not prohibited.
+- Hacking the environment itself. (For example, eavesdropping on other vehicles' communication or injecting fake data.)
 
-## SW Division SIM Qualifying Rules
+## Sim to Real Division SIM Qualifying
 
-- Matchmaking battles are held in an online simulation environment provided by the organizers.
-- Participating teams only need to submit their code. After submission, building, racing, and ranking are performed automatically.
-- There is a daily limit on the number of code submissions.
+### Overview { #preliminaries-abst }
 
-### Ranking System (SIM Qualifying)
+- Matchmaking battles are held in the online simulation environment provided by the organizers.
+- Participating teams only submit code. After submission, building, racing and ranking are performed automatically.
+- For details, see the [Submission Procedure](./submission.en.md).
 
-When code is submitted, an online race is automatically run with the following 3 vehicles simultaneously:
+### Ranking System { #preliminaries-race }
+
+- Races are held with 3 vehicles simultaneously. The race is 6 laps, and the position in each race is determined by finishing order.
+- When code is submitted, a race with the following 3 vehicles is run online automatically. The rating goes up or down depending on the race result. The higher the rating, the higher the rank.
 
 | Vehicle | Description |
 | --- | --- |
-| Vehicle 1 | Team that submitted the code (Challenger) |
-| Vehicle 2 | Another team with a similar rank to the Challenger (Opponent) |
+| Vehicle 1 | The team that submitted the code (challenger) |
+| Vehicle 2 | Another team close to the challenger's rank band (opponent) |
 | Vehicle 3 | NPC provided by the organizers |
 
-Ranking changes based on race results are as follows:
+### Rules { #preliminaries-rule }
 
-- If the Challenger wins, they move up in the ranking.
-- If the time limit is reached or the NPC wins, it is a draw and the ranking does not change.
-- In addition to when code is submitted, a team may race as an opponent when other teams submit code. Losing in such cases will also lower the ranking.
+- The basic rules follow the common rules above.
+- There is a daily limit on the number of code submissions.
 
-## SW Division SIM Finals Rules
+## Sim to Real Division SIM Finals { #semifinal }
 
-- Real-time simultaneous battles are held in the simulation environment on PCs provided by the organizers at the finals venue.
-- Participants cannot use their own PCs.
-- If a vehicle becomes stuck due to a crash, manual recovery is permitted. (TBD)
+### Overview { #semifinal-abst }
 
-### Ranking System (SIM Finals)
+- Real-time simultaneous battles are held in the simulation environment on PCs provided by the organizers at the SIM Finals venue.
+- For details of the SIM Finals, see the [SIM Finals special page](./sim-finals.en.md).
 
-There are no NPCs; races are run simultaneously with 4 teams' vehicles. Tournament-style competition between groups of 4 teams is planned.
+### Ranking System { #semifinal-race }
 
-| Vehicle | Description |
-| --- | --- |
-| Vehicle 1 | Finalist Team 1 |
-| Vehicle 2 | Finalist Team 2 |
-| Vehicle 3 | Finalist Team 3 |
-| Vehicle 4 | Finalist Team 4 |
+Ranking within each race
 
-## SW Division Real Vehicle Finals Rules
+- Races are held with 4 vehicles simultaneously. The race is 6 laps, and the position in each race is determined by finishing order.
+    - However, if the time runs out before a vehicle finishes, the more laps + sections completed, the higher the position.
+    - If still tied, the fewer penalties, the higher the position.
+    - If still tied, the SIM Qualifying position decides.
+- Starting positions are determined by the SIM Qualifying ranking.
 
-- Real-time simultaneous battles are held using real vehicles at City Circuit Tokyo Bay (CCTB).
-- Participants' code runs on PCs installed in the karts. Required PCs are provided by the organizers.
-- If a vehicle becomes stuck due to a crash, manual recovery is permitted. (TBD)
+Ranking for the SIM Finals as a whole
+
+- Each class runs 4 races, and the top 2 teams of each race advance to the Real Vehicle Finals on September 20.
+- Due to time constraints, no races between the top teams are held in the SIM Finals to decide the overall order.
+- The SIM Finals ranking is decided by grouping teams by finishing position in their race. The 4 teams that finished 1st in their race are ranked 1–4, the 4 teams that finished 2nd are ranked 5–8, the 4 teams that finished 3rd are ranked 9–12, and the 4 teams that finished 4th are ranked 13–16. Within each group, the order is decided as follows.
+    1. The fewer penalties, the higher the position (penalties are rear-end collisions, wall collisions and input anomalies detected automatically by AWSIM)
+    2. If the number of penalties is equal, the SIM Qualifying rank
+
+    *This follows the same idea as the Real Vehicle Finals on September 20: driving that takes safety into account is prioritized.<br>
+    *This ranking is used to decide the starting positions in the Real Vehicle Finals. There is no award based on the SIM Finals ranking, so the SIM Finals are positioned as a selection round rather than a final.
+
+![s2r_sim_tournament](./images/s2r_sim_tournament.png)
+
+### Rules { #semifinal-rule }
+
+- The basic rules follow the common rules above.
+- Races start forcibly at the scheduled start time. A team whose setup is not complete either continues working and aims to join mid-race, or retires.
+- If a vehicle gets stuck because of a crash or behaves unexpectedly, the organizers will not help it recover.
+- Participants may perform any operation from their own terminal and RViz (but cannot operate the AWSIM screen). The expected operations are:
+    - Restarting Autoware
+    - Re-setting the self-position (localization)
+    - Moving the vehicle by manual driving when it is stuck
+    - Switching gear and issuing turbo commands with the `ros2 topic` command
+- However, you must report to the organizers before operating. Frequent use of manual driving is prohibited. Operations that affect anything other than your own ROS_DOMAIN_ID are also prohibited.
+
+## Sim to Real Division Real Vehicle Finals
+
+### Overview { #final-abst }
+
+- Real-time simultaneous battles are held with real vehicles at City Circuit Tokyo Bay (CCTB).
+- Each team's code runs on the PC mounted on the kart. The PCs needed for the work are provided by the organizers.
+- Because real vehicles are used, the match structure and rules take safety into account.
+- Details will be announced later.
+
+### Ranking System { #final-race }
+
+- Races are free-running within a time limit, with 4 vehicles simultaneously.
+- Vehicles keep running for the specified time (7 minutes). There is no upper limit on the number of laps.
+- The ranking is decided in the following order.
+    1. The fewer fouls, the higher the position
+    2. If the number of fouls is equal, the more laps + sections completed, the higher the position
+        - For example, between a team that completed 2 laps and reached the 2nd section of lap 3 and a team that completed 2 laps and reached the 3rd section of lap 3, the latter ranks higher
+    3. If still tied, the SIM Finals ranking
+- Starting positions are determined by the SIM Finals ranking. However, for safety, the spacing between vehicles is larger than in the SIM.
+- After the tournament within each class, a mixed-class race among the top teams of each class is held.
+
+![s2r_kart_tournament](./images/s2r_kart_tournament.png)
+
+### Definition of Fouls { #final-foul }
+
+The following driving counts as a foul (regardless of whether it is intentional, accidental, or caused by a malfunction).
+
+- Driving extremely slowly, or stopping partway without reason
+    - This is to prevent passive driving intended to avoid fouls
+- Driving while obstructing the path of other vehicles
+- Obstructing other vehicles when returning to the course
+- Stopping anywhere other than the edge of the course (if you need to stop, pull over to the edge of the course)
+- Collisions **other than** the following cases
+    - Grazing another vehicle while trying to overtake it (when it is not path obstruction)
+    - A collision from behind when the vehicle ahead decelerates suddenly
+    - A collision from behind when the vehicle ahead is returning to the course
+    - A collision from behind when the vehicle ahead is driving dangerously
+- Prohibited actions listed in the rules
+
+### Rules { #final-rule }
+
+- The basic rules follow the common rules above.
+- If a vehicle gets stuck because of a crash or behaves unexpectedly, the organizers will not help it recover (neither by remote operation nor by physical intervention).
+    - However, the organizers may perform an emergency stop or move the vehicle if they judge the situation to be dangerous.
+- Participants may perform any operation from their own terminal and RViz.
+- However, you must report to the organizers before operating. Frequent use of manual driving is prohibited. Operations that affect anything other than your own ROS_DOMAIN_ID are also prohibited.
 
 ### Notes
 
-- Participating teams are required to perform integration work on the real vehicle and be present during the race. (Organizers will provide support)
-- Participating teams must stop the vehicle at the operator's instruction and perform remote control as necessary.
-- Racing will be stopped under the following conditions:
-    - If the course walls are significantly displaced.
-    - If the vehicle significantly deviates from the course.
-    - If staff instructs a stop for safety or other reasons.
+- Participating teams must carry out the integration work on the real vehicle and be present during the run. (The organizers support the work.)
+- Participating teams must stop the vehicle on the operator's instruction and, if necessary, operate it remotely.
+- The run is stopped in the following cases.
+    - The course walls have moved significantly.
+    - The vehicle has deviated significantly from the course.
+    - Staff instruct a stop for safety or other reasons.


### PR DESCRIPTION
## 概要

`sw-class.en.md` が 2026-07 時点の内容のままで、#61 / #71 / #73 / #74 で更新された日本語版ルールと食い違っていました（実車の速度上限 30 km/h、「制限時間10分」、「NPC勝利は引き分け」、「手動復帰可（TBD）」、評価・練習・決勝の全スクリプトで `--wall-recovery off` なのに「壁衝突時は自動で姿勢修正」など）。ペナルティ表（CRASH/WALL/OVER/BLOCK・5 km/h）、オーバーテイクレーン、V2X による後方妨害の禁止、SIM決勝・実機決勝の順位決定方式、`{ #id }` アンカーも英語版にありませんでした。

## 変更内容

- 現行の `sw-class.ja.md`（base 61ef527、`main` に対して差分なしを確認済み）を忠実に英訳し、英語版を全面置き換え（アンカー14個・画像パス・admonition を維持）
- 英語版で未整備のアンカー（development-guide / simulator / faq）へのリンクは、コマンドを本文に記載する形にしてリンク切れを回避
- `./sim-finals.en.md` へのリンクは SIM決勝ページ英訳 PR（DOCS-20）に依存します
- `.markdown-link-check.json` に `^#prohibited$` を追加。ページ内で `{ #prohibited }` アンカーへ自己参照するリンクがあり、markdown-link-check は同一ファイル内の attr_list アンカーを解決できないため、既存の `#env-check` 等と同じパターンで無視リストに追加しました

## 確認

`mkdocs build`（非strict、CIと同じコマンド）: 変更前 19 件の WARNING、変更後 20 件。新規追加は 1 件のみで、想定どおり `competition/sw-class.en.md` から `./sim-finals.en.md` へのリンク切れ（DOCS-20 が解消）です。それ以外に新規・消滅した WARNING はありません。

`grep -c '{ #' docs/competition/sw-class.en.md docs/competition/sw-class.ja.md` → 14 / 14 (一致)。

`pre-commit run --files docs/competition/sw-class.en.md .markdown-link-check.json`: markdownlint / prettier / end-of-file-fixer 等はすべて Passed。markdown-link-check は `./sim-finals.en.md`（DOCS-20 依存、未マージのため 400）の1件のみ Failed で、それ以外の内部リンクは Passed。

ルールの意味は変えていません。日本語版の記述どおりに訳しています。

Team Hayes（非日本語話者チーム）より。誤訳があればご指摘ください。

## Summary

`sw-class.en.md` was still the July 2026 text and contradicted the Japanese rules updated in #61/#71/#73/#74. Examples: real-vehicle speed limit 30 km/h (JA: ~25 km/h); a "10-minute time limit"; "NPC win = draw"; "manual recovery permitted (TBD)"; and automatic wall correction, which all race/practice/eval scripts disable with `--wall-recovery off`. The EN page also lacked the penalty table (CRASH/WALL/OVER/BLOCK at 5 km/h), the overtaking-lane rule, the V2X rear-obstruction prohibition, the SIM/kart finals ranking method, and all `{ #id }` anchors.

## Changes

- Full replacement with a faithful translation of the current `sw-class.ja.md` (base 61ef527, confirmed unchanged against current `main`), 14 anchors, image paths and admonitions preserved.
- Links to EN pages that lack the needed anchors (development guide, simulator, FAQ) are replaced by inlined commands, so there are no dead anchors.
- The link to `./sim-finals.en.md` depends on the SIM Finals translation PR (DOCS-20).
- Added `^#prohibited$` to `.markdown-link-check.json`. The page self-links to its own `{ #prohibited }` attr_list anchor, which markdown-link-check cannot resolve for same-file links; this follows the same convention already used for `#env-check` and the other existing entries.

## Checks

`mkdocs build` (non-strict, same command as CI): 19 warnings before, 20 after. The only new warning is the expected `./sim-finals.en.md` link, which the dependent PR (DOCS-20) resolves. No other warnings changed.

`grep -c '{ #' docs/competition/sw-class.en.md docs/competition/sw-class.ja.md` -> 14 and 14, matching.

`pre-commit run --files docs/competition/sw-class.en.md .markdown-link-check.json`: all hooks pass except markdown-link-check, which fails only on the expected `./sim-finals.en.md` dependency link (DOCS-20 not yet merged); all other internal links pass.

No rule meaning changed; the text follows the Japanese page.

From Team Hayes (a non-Japanese team). Corrections to the translation are welcome.

---
Team Hayes (Ajayaditya Lokchandra, Nithisha Venkatesh)

本PRはAIコーディング支援を用いて作成し、上記の確認手順で検証しました。 / Prepared with AI coding assistance and verified with the checks above.
