### PR TITLE
docs(vehicle): add English translation of the real-vehicle finals operation guide

### DIFF
--- a/docs/vehicle/operation.en.md
+++ b/docs/vehicle/operation.en.md
@@ -1,0 +1,78 @@
+# Participant Operations at the Real-Vehicle Finals
+
+!!! warning "WIP"
+
+    This page is under construction. Confirmed information will be updated as it becomes available.
+
+This page describes how participating teams operate the real vehicle at the Sim to Real SW Division real-vehicle finals (September 20, City Circuit Tokyo Bay). For the competition rules and how rankings are decided, see the [Sim to Real Division rules (Japanese)](https://automotiveaichallenge.github.io/aichallenge-documentation-racingkart/competition/sw-class.html#final-abst); for the schedule on the day and the operations allowed during a run slot, see the [Real-Vehicle Finals Special Page](../competition/kart-finals.en.md).
+
+!!! warning "The code you submitted in advance runs on the vehicle as-is"
+    During a run slot you cannot change or rebuild any code on the vehicle PC. On the day, you can only tune parameters and operate the vehicle manually by remote control. Any value you want to adjust while watching the run **must be implemented so that it can be changed at runtime (dynamic reconfigure)**.
+
+## Part 1: Advance Preparation
+
+### 1-1. Submitting Your Code
+
+Submit the code to be used at the real-vehicle finals to the organizers by the specified deadline.
+
+| Item | Details |
+| --- | --- |
+| Submission deadline | 9/14 |
+| Submission | The complete code to run at the real-vehicle finals (same `aichallenge_submit.tar.gz` format as the SIM qualifiers) |
+
+After submission, the organizers build and launch it on the vehicle to check that it works, and will contact you individually if a problem is found. **The code cannot be replaced after the deadline**, so before submitting, make sure that `make autoware-build` succeeds locally and that the stack launches and drives.
+
+### 1-2. Supporting dynamic reconfigure
+
+Make the parameters you want to tune on the day changeable without restarting the node. Declare them as ROS 2 parameters and receive changes with `rclcpp::Node::add_on_set_parameters_callback` (C++) or `Node.add_on_set_parameters_callback` (Python). Typical targets are control gains, limits on target speed and acceleration/deceleration, and decision thresholds for obstacle avoidance and overtaking.
+
+Parameters that do not support this will not take effect, even if you edit the launch file or YAML on the day, unless you restart Autoware. Restarting is possible but is not recommended because it consumes your limited run slot.
+
+### 1-3. Implementing a Tuning TUI (Recommended)
+
+Tuning on the day is done from a TUI (terminal UI) prepared by each participating team.
+
+| Item | Requirement |
+| --- | --- |
+| Launch | When the organizers run `make tui` on the vehicle PC, the submission's `aichallenge_submit/tui.bash` is executed inside the autoware container. Include this script in your submission |
+| Function | It must let you view and change, while driving, the parameters you made dynamic-reconfigure-capable in 1-2 |
+| Runtime environment | It must work inside the autoware container (ROS 2 environment, with `ROS_DOMAIN_ID` matching the stack). It is operated over SSH from the PC in the operation booth, so do not assume X forwarding |
+
+The organizers standardize the launch method so that the TUI is already launched and displayed when a team arrives at the operation booth. `make tui` runs the TUI inside tmux, so the TUI survives an SSH disconnection and you can return to the same screen after reconnecting.
+
+### 1-4. Clearing the Safety Gates (Strongly Recommended)
+
+Clearing the [safety gates](../competition/sw-class.en.md#safety-gate) (obstacle stop, NPC overtaking, lane keeping) is not mandatory but is strongly recommended. At the real-vehicle finals, the number of fouls directly affects the ranking, and collisions and stops count as fouls as they are. For how to run them, see [Running the Safety Gate Scenarios (Japanese)](https://automotiveaichallenge.github.io/aichallenge-documentation-racingkart/development/development-guide.html#safety-gate).
+
+### 1-5. Handling Behavior Specific to the Real Vehicle
+
+There are differences between the simulator and the real vehicle, such as V2X communication delay, starting off with the steering turned, and the starting grid order. Check [Notes on Running on the Real Vehicle](../competition/kart-finals.en.md#real-vehicle-notes) and add any necessary handling to your code. In particular, be sure to add handling before submission so that your stuck detection does not trigger while waiting at the start and make the vehicle reverse or start a multi-point turn.
+
+## Part 2: Operations on the Day
+
+### 2-1. State When You Arrive at the Operation Booth
+
+By the time a participating team arrives at the operation booth, the organizers will have completed the following preparation:
+
+1. The submitted code has been built on the vehicle PC
+2. Autoware, driver and zenoh have been launched (rosbags are recorded by the organizers and are not provided to participating teams)
+3. The booth PC is connected to the vehicle PC over SSH, and in that terminal the tuning TUI has been launched and is displayed via `make tui`
+
+Participating teams take over operation from this state. All operations on the vehicle PC are performed over this SSH connection.
+
+### 2-2. Tuning with the TUI
+
+Change parameters from the displayed TUI. Changes take effect even while driving. You can also watch the run in RViz ([Remote Operation](remote.en.md)).
+
+The time available for tuning depends on how the match progresses. The semifinal has a free run (10–25 minutes), which is the main tuning time. In the final, the standby time is short and there is no room to fine-tune parameters ([Match Schedule](../competition/kart-finals.en.md#match-schedule)).
+
+!!! warning "Notify the organizers before operating"
+    Before performing any operation on the vehicle, including parameter changes, you must notify the organizers (re-setting the self-position and issuing gear-switch and turbo commands via `ros2 topic` do not require notification). Operations that affect anything other than your own team's `ROS_DOMAIN_ID` are prohibited ([Sim to Real Division rules (Japanese)](https://automotiveaichallenge.github.io/aichallenge-documentation-racingkart/competition/sw-class.html#final-rule)).
+
+### 2-3. Remote Manual Operation with a Game Controller
+
+Each participating team is given a game controller (Logicool F310). With it you can operate the vehicle manually and remotely. For the button and axis assignments, see [Remote Operation](remote.en.md).
+
+- **You can switch between autonomous driving and manual operation at any time.**
+- Participating teams must recover the vehicle themselves if it gets stuck or behaves unexpectedly. The organizers provide no support (remote operation or physical intervention).
+- However, **excessive use of manual driving is prohibited**. In addition, if the organizers judge a situation to be dangerous, they may perform an emergency stop or move the vehicle themselves.


### PR DESCRIPTION
「実機決勝での参加者操作」（`vehicle/operation.ja.md`）の英語版を追加し、`sw-class.en.md` の「Safety Gates」見出しに `{ #safety-gate }` アンカーを付けます。9/14 のコード凍結、当日は dynamic reconfigure 経由のチューニングのみ可能であること、TUI の要件、操作前の申告ルールが英語で読めるようになります。

- `sw-class.en.md` / `development-guide.en.md` に対応節が無いリンク（`#final-abst`、`#final-rule`、安全ゲート実行手順）は日本語ページの絶対 URL にしています。
- `../competition/kart-finals.en.md` へのリンク（3箇所）と `remote.en.md` へのリンク（2箇所）は相対パスのまま残しています。前者は現在オープン中の PR #79（`kart-finals.en.md` を追加）と、後者は姉妹カード（`vehicle/remote` 英訳）とマージ時に一緒になる想定で、リンク切れは意図的です。
- 確認のお願い: 本文の `make tui` → autoware コンテナ内で `aichallenge_submit/tui.bash` を実行、という記述に対応するターゲットが aichallenge-racingkart の `dev` / `main` / #308 に見当たりません（`dev` には host 側で `vehicle/tui.py` を起動する `make vehicle-tui` のみ）。翻訳は原文どおりにしていますが、正しいターゲット名・契約を教えていただければ日英両方を修正します。
- なお、この PR #79 は `vehicle/operation` の英訳へ絶対 URL でリンクしていますが（現状 `sw-class.en.md` の日本語版ページを指す形）、本 PR がマージされたら #79 側は `../vehicle/operation.en.md` への相対リンクに戻すべきです。

## 確認

`mkdocs build`（非strict）: base（9dae4a7）19 件 → 本 PR適用後 21 件。

新規に出た WARNING（5件、いずれも既知の依存先の未マージによるもの）:
```
WARNING -  Doc file 'vehicle/operation.en.md' contains a link '../competition/kart-finals.en.md', but the target 'competition/kart-finals.en.md' is not found among documentation files.
WARNING -  Doc file 'vehicle/operation.en.md' contains a link '../competition/kart-finals.en.md#match-schedule', but the target 'competition/kart-finals.en.md' is not found among documentation files.
WARNING -  Doc file 'vehicle/operation.en.md' contains a link '../competition/kart-finals.en.md#real-vehicle-notes', but the target 'competition/kart-finals.en.md' is not found among documentation files.
WARNING -  Doc file 'vehicle/operation.en.md' contains a link 'remote.en.md', but the target 'vehicle/remote.en.md' is not found among documentation files.
WARNING -  Doc file 'vehicle/operation.en.md' contains a link 'remote.en.md', but the target 'vehicle/remote.en.md' is not found among documentation files.
```
加えて新規に1件（`kart-finals.ja.md` から `vehicle/operation.ja.md` への日本語版内リンクが、英語版に `operation.en.md` ができたことで英語ビルド上のフォールバックから外れて出現するもの。これは `vehicle/operation` 翻訳カードに付随する副作用として `DOCS-26` のリスク欄に記載済みです。）:
```
WARNING -  Doc file 'competition/kart-finals.ja.md' contains a link '../vehicle/operation.ja.md', but the target 'vehicle/operation.ja.md' is not found among documentation files.
```

解消された WARNING（4件、`operation.ja.md` が英語フォールバックとして使われなくなったため）:
```
WARNING -  Doc file 'vehicle/operation.ja.md' contains a link '../competition/sw-class.ja.md#final-abst', but the target 'competition/sw-class.ja.md' is not found among documentation files.
WARNING -  Doc file 'vehicle/operation.ja.md' contains a link '../competition/sw-class.ja.md#final-rule', but the target 'competition/sw-class.ja.md' is not found among documentation files.
WARNING -  Doc file 'vehicle/operation.ja.md' contains a link '../competition/sw-class.ja.md#safety-gate', but the target 'competition/sw-class.ja.md' is not found among documentation files.
WARNING -  Doc file 'vehicle/operation.ja.md' contains a link '../development/development-guide.ja.md#safety-gate', but the target 'development/development-guide.ja.md' is not found among documentation files.
```

`pre-commit run --files docs/vehicle/operation.en.md docs/competition/sw-class.en.md`: markdownlint / prettier / end-of-file-fixer 等はすべて Passed。markdown-link-check は上記の未マージ依存先4件のみ Failed で、それ以外の内部リンクは Passed。

`{ #safety-gate }` アンカーは本カードが `sw-class.en.md` に追加します。DOCS-03（`sw-class.en.md` 全面英訳）も同じアンカーを含んだ全文で置き換えるため、両カードが独立ブランチのまま先にマージされた方がアンカーを所有し、後からマージする方はこの1行差分を落としてください（重複定義を避けるため）。

依存関係: `#safety-gate` アンカーは DOCS-03 の `sw-class.en.md` 再同期 PR で追加されます（重複定義を避けるため本 PR からは外しました）。先にそちらをマージいただくとリンクが解決します。また `kart-finals.en.md`（#79）と `vehicle/remote.en.md` へのリンクは、それぞれの英訳 PR と同時にマージすると解決します。

## Summary

Adds `vehicle/operation.en.md` (English translation of the real-vehicle finals participant-operations guide) and a `{ #safety-gate }` anchor on the existing "Safety Gates" heading of `sw-class.en.md`. Non-Japanese finalists can now read the 9/14 code freeze, the dynamic-reconfigure-only tuning rule, the TUI requirements and the notify-before-operating rule.

- Links whose target section has no English equivalent (`#final-abst`, `#final-rule`, the safety-gate run procedure) point to the Japanese page's absolute URL, marked "(Japanese)".
- Links to `../competition/kart-finals.en.md` (three places) and `remote.en.md` (two places) are left as relative links on purpose: the former depends on the currently open PR #79 (which adds `kart-finals.en.md`), the latter on the sibling `vehicle/remote` translation card. Both are expected to merge together with this page.
- Question for maintainers: the page says the organisers run `make tui`, which executes the submission's `aichallenge_submit/tui.bash` inside the autoware container. No such target exists in aichallenge-racingkart `dev`, `main` or PR #308 (`dev` has only `make vehicle-tui`, which starts the host-side `vehicle/tui.py`). The translation keeps the original wording; if you confirm the intended target/contract we will update both languages.
- Note: PR #79 currently links to `vehicle/operation` via an absolute Japanese URL. Once this PR merges, #79 should switch that back to a relative link to `../vehicle/operation.en.md`.

## Checks

`mkdocs build` (non-strict): 19 warnings on base (9dae4a7) -> 21 after this PR.

New warnings (5, all expected pending-dependency links):
```
WARNING -  Doc file 'vehicle/operation.en.md' contains a link '../competition/kart-finals.en.md', but the target 'competition/kart-finals.en.md' is not found among documentation files.
WARNING -  Doc file 'vehicle/operation.en.md' contains a link '../competition/kart-finals.en.md#match-schedule', but the target 'competition/kart-finals.en.md' is not found among documentation files.
WARNING -  Doc file 'vehicle/operation.en.md' contains a link '../competition/kart-finals.en.md#real-vehicle-notes', but the target 'competition/kart-finals.en.md' is not found among documentation files.
WARNING -  Doc file 'vehicle/operation.en.md' contains a link 'remote.en.md', but the target 'vehicle/remote.en.md' is not found among documentation files.
WARNING -  Doc file 'vehicle/operation.en.md' contains a link 'remote.en.md', but the target 'vehicle/remote.en.md' is not found among documentation files.
```
Plus one more new warning (a side effect noted already in DOCS-26's Risks section: once an English `operation.en.md` exists, `kart-finals.ja.md`'s own link to `vehicle/operation.ja.md` no longer resolves via the English-build fallback):
```
WARNING -  Doc file 'competition/kart-finals.ja.md' contains a link '../vehicle/operation.ja.md', but the target 'vehicle/operation.ja.md' is not found among documentation files.
```

Warnings resolved (4, since `operation.ja.md` is no longer used as the English-build fallback):
```
WARNING -  Doc file 'vehicle/operation.ja.md' contains a link '../competition/sw-class.ja.md#final-abst', but the target 'competition/sw-class.ja.md' is not found among documentation files.
WARNING -  Doc file 'vehicle/operation.ja.md' contains a link '../competition/sw-class.ja.md#final-rule', but the target 'competition/sw-class.ja.md' is not found among documentation files.
WARNING -  Doc file 'vehicle/operation.ja.md' contains a link '../competition/sw-class.ja.md#safety-gate', but the target 'competition/sw-class.ja.md' is not found among documentation files.
WARNING -  Doc file 'vehicle/operation.ja.md' contains a link '../development/development-guide.ja.md#safety-gate', but the target 'development/development-guide.ja.md' is not found among documentation files.
```

`pre-commit run --files docs/vehicle/operation.en.md docs/competition/sw-class.en.md`: all hooks pass except markdown-link-check, which fails only on the four pending-dependency links above; all other internal links pass.

The `{ #safety-gate }` anchor is added by this card. DOCS-03 (the full `sw-class.en.md` retranslation) also ships this anchor as part of its full-file replacement, so whichever of the two merges first should own the anchor, and the other should drop this one-line hunk to avoid a duplicate definition.

Dependencies: the `#safety-gate` anchor is added by the `sw-class.en.md` resync PR (removed here to avoid defining it twice), so that link resolves once it merges. Links to `kart-finals.en.md` (#79) and `vehicle/remote.en.md` resolve when those translation PRs merge.

---
Team Hayes (Ajayaditya Lokchandra, Nithisha Venkatesh)

本PRはAIコーディング支援を用いて作成し、上記の確認手順で検証しました。 / Prepared with AI coding assistance and verified with the checks above.
