### PR TITLE
docs(specifications): resync interface.en.md and document /v2x/vehicle_positions

### DIFF
--- a/docs/specifications/interface.en.md
+++ b/docs/specifications/interface.en.md
@@ -1,56 +1,138 @@
 # Interface
 
-## List
+## Domain ID Namespaces
+
+To support multiple vehicles, this competition uses the ROS 2 domain ID feature to separate topic namespaces.
+
+| Domain ID | Purpose |
+| ---------- | ---- |
+| 0          | AWSIM (simulator) |
+| 1–4        | Each vehicle |
+
+AWSIM connects directly to each vehicle's domain (1–4), publishes sensor data and vehicle status in each domain, and subscribes to control commands. This is how communication between the simulator and each vehicle is realized. In normal (single-vehicle) development you do not need to be aware of domain IDs.
+
+## Main Topic Communication between AWSIM and Autoware
+
+The sequence diagram below shows the flow of topic communication between AWSIM and Autoware. AWSIM connects directly to each vehicle's domain (Domain N), publishes sensor data and status under the Autoware-side topic names, and subscribes to control commands.
+
+```mermaid
+sequenceDiagram
+    participant AWSIM as AWSIM
+    participant Autoware as Autoware<br/>(Domain N)
+
+    Note over AWSIM,Autoware: Sensor data (AWSIM → Autoware)
+    AWSIM->>Autoware: /sensing/gnss/nav_sat_fix
+    AWSIM->>Autoware: /sensing/imu/imu_raw
+    AWSIM->>Autoware: /sensing/lidar/scan
+    AWSIM->>Autoware: /v2x/vehicle_positions
+
+    Note over AWSIM,Autoware: Control commands (AWSIM ← Autoware)
+    Autoware->>AWSIM: /control/command/control_cmd
+
+    Note over AWSIM,Autoware: AWSIM status and commands
+    AWSIM->>Autoware: /awsim/status
+    AWSIM->>Autoware: /awsim/state
+    Autoware->>AWSIM: /awsim/cmd
+```
+
+## Topic List
+
+### Vehicle Interface
 
 | Interface    | Name                                 | Type                                                     |
 | ------------ | ------------------------------------ | -------------------------------------------------------- |
-| Service      | `/control/control_mode_request`      | `autoware_auto_vehicle_msgs/srv/ControlModeCommand`      |
 | Publisher    | `/vehicle/status/control_mode`       | `autoware_auto_vehicle_msgs/msg/ControlModeReport`       |
 | Subscription | `/control/command/control_cmd`       | `autoware_auto_control_msgs/msg/AckermannControlCommand` |
 | Subscription | `/control/command/actuation_cmd`     | `tier4_vehicle_msgs/msg/ActuationCommandStamped`         |
+| Publisher    | `/vehicle/status/actuation_status`   | `tier4_vehicle_msgs/msg/ActuationStatusStamped`          |
 | Publisher    | `/vehicle/status/velocity_status`    | `autoware_auto_vehicle_msgs/msg/VelocityReport`          |
 | Publisher    | `/vehicle/status/steering_status`    | `autoware_auto_vehicle_msgs/msg/SteeringReport`          |
 | Subscription | `/control/command/gear_cmd`          | `autoware_auto_vehicle_msgs/msg/GearCommand`             |
 | Publisher    | `/vehicle/status/gear_status`        | `autoware_auto_vehicle_msgs/msg/GearReport`              |
-| Publisher    | `/sensing/gnss/pose_with_covariance` | `geometry_msgs/msg/PoseWithCovarianceStamped`            |
-| Publisher    | `/sensing/imu/imu_raw`               | `sensor_msgs/msg/Imu`                                    |
-| Publisher    | `/aichallenge/objects`               | `std_msgs/msg/Float64MultiArray`                         |
-| Publisher    | `/aichallenge/pitstop/area`          | `std_msgs/msg/Float64MultiArray`                         |
-| Publisher    | `/aichallenge/pitstop/condition`     | `std_msgs/msg/Int32`                                     |
-| Publisher    | `/aichallenge/pitstop/status`        | `std_msgs/msg/Float32`                                   |
+
+### Sensors
+
+| Interface | Name                                 | Type                                          |
+| --------- | ------------------------------------ | ---------------------------------------------- |
+| Publisher | `/sensing/gnss/nav_sat_fix`          | `sensor_msgs/msg/NavSatFix`                   |
+| Publisher | `/sensing/imu/imu_raw`               | `sensor_msgs/msg/Imu`                         |
+| Publisher | `/sensing/lidar/scan`                | `sensor_msgs/msg/LaserScan`                   |
+| Publisher | `/sensing/camera/image_raw`          | `sensor_msgs/msg/Image`                       |
+| Publisher | `/sensing/camera/camera_info`        | `sensor_msgs/msg/CameraInfo`                  |
+
+### V2X
+
+| Interface | Name                                 | Type                                          |
+| --------- | ------------------------------------ | ---------------------------------------------- |
+| Publisher | `/v2x/vehicle_positions`             | `v2x_msgs/msg/V2XVehiclePositionArray`        |
+
+### Simulation Management
+
+Topics that AWSIM exchanges directly in each vehicle's domain (N=1–4).
+
+| Interface    | Name                                | Type                             |
+| ------------ | ----------------------------------- | --------------------------------- |
+| Publisher    | `/awsim/status`                     | `std_msgs/msg/Float32MultiArray` |
+| Publisher    | `/awsim/state`                      | `std_msgs/msg/String`            |
+| Subscription | `/awsim/control_mode_request_topic` | `std_msgs/msg/Bool`              |
+| Subscription | `/awsim/cmd`                        | `std_msgs/msg/Float32MultiArray` |
+
+### Admin Topics (Domain 0)
+
+Topics used for the overall management of AWSIM. You do not need to be aware of them in normal development.
+
+| Interface    | Name                       | Type                             |
+| ------------ | -------------------------- | --------------------------------- |
+| Publisher    | `/admin/awsim/state`       | `std_msgs/msg/String`            |
+| Subscription | `/admin/awsim/start`       | `std_msgs/msg/Bool`              |
+| Subscription | `/admin/awsim/reset`       | `std_msgs/msg/Empty`             |
+
+## Topic Details
+
+Details of the message fields of each topic.
+
+- **Control commands**: [`control_cmd`](#controlcommandcontrol_cmd) / [`actuation_cmd`](#controlcommandactuation_cmd)
+- **Vehicle status**: [`actuation_status`](#vehiclestatusactuation_status) / [`velocity_status`](#vehiclestatusvelocity_status) / [`steering_status`](#vehiclestatussteering_status) / [`gear_status`](#vehiclestatusgear_status)
+- **Sensors**: [`gnss`](#sensinggnssnav_sat_fix) / [`imu`](#sensingimuimu_raw) / [`lidar`](#sensinglidarscan) / [`camera`](#sensingcameraimage_raw)
+- **V2X**: [`v2x/vehicle_positions`](#v2xvehicle_positions)
+- **Simulation**: [`awsim/status`](#awsimstatus) / [`awsim/state`](#awsimstate) / [`awsim/cmd`](#awsimcmd) / [`admin/awsim/state`](#adminawsimstate)
 
 ### `/control/command/control_cmd`
 
-| Name                                | Description           |
-| ----------------------------------- | --------------------- |
-| stamp                               | Message timestamp     |
-| lateral.stamp                       | Unused                |
-| lateral.steering_tire_angle         | Target steering angle |
-| lateral.steering_tire_rotation_rate | Unused                |
-| longitudinal.stamp                  | Unused                |
-| longitudinal.speed                  | Unused                |
-| longitudinal.acceleration           | Target acceleration   |
-| longitudinal.jerk                   | Unused                |
+| Name                                | Description               |
+| ----------------------------------- | ------------------------- |
+| stamp                               | Message send time         |
+| lateral.stamp                       | Unused                    |
+| lateral.steering_tire_angle         | Target steering angle (rad) |
+| lateral.steering_tire_rotation_rate | Unused                    |
+| longitudinal.stamp                  | Unused                    |
+| longitudinal.speed                  | Unused                    |
+| longitudinal.acceleration           | Target acceleration (m/s²) |
+| longitudinal.jerk                   | Unused                    |
 
 ### `/control/command/actuation_cmd`
 
+Unused in the AWSIM environment, because AWSIM receives `/control/command/control_cmd` directly. On the real vehicle, the `raw_vehicle_cmd_converter` node automatically converts `/control/command/control_cmd` into `/control/command/actuation_cmd`.
+
 | Name                  | Description                      |
-| --------------------- | -------------------------------- |
-| header.stamp          | Message timestamp                |
+| --------------------- | --------------------------------- |
+| header.stamp          | Message send time                |
 | header.frame_id       | Unused                           |
-| actuation.accel_cmd   | Accel command value (0.0 to 1.0) |
-| actuation.brake_cmd   | Brake command value (0.0 to 1.0) |
-| actuation.steer_cmd   | Tire angle command value (rad)   |
+| actuation.accel_cmd   | Accelerator command (0.0 to 1.0) |
+| actuation.brake_cmd   | Brake command (0.0 to 1.0)       |
+| actuation.steer_cmd   | Tire angle command (rad)         |
 
 ### `/vehicle/status/actuation_status`
 
+A status used only on the real vehicle; it is not published in the AWSIM environment. On the real vehicle, the `raw_vehicle_cmd_converter` node uses it as input for the current actuator values.
+
 | Name                  | Description                      |
-| --------------------- | -------------------------------- |
+| --------------------- | --------------------------------- |
 | header.stamp          | Data acquisition time            |
 | header.frame_id       | Unused                           |
-| status.accel_status   | Accel current value (0.0 to 1.0) |
-| status.brake_status   | Brake current value (0.0 to 1.0) |
-| status.steer_status   | Tire angle current value (rad)   |
+| status.accel_status   | Current accelerator value (0.0 to 1.0) |
+| status.brake_status   | Current brake value (0.0 to 1.0) |
+| status.steer_status   | Current tire angle (rad)         |
 
 ### `/vehicle/status/velocity_status`
 
@@ -65,75 +147,169 @@
 ### `/vehicle/status/steering_status`
 
 | Name                | Description           |
-| ------------------- | --------------------- |
+| ------------------- | ---------------------- |
 | stamp               | Data acquisition time |
 | steering_tire_angle | Steering angle        |
 
 ### `/control/command/gear_cmd`
 
 | Name    | Description          |
-| ------- | -------------------- |
-| stamp   | Message timestamp    |
-| command | Gear type            |
+| ------- | --------------------- |
+| stamp   | Message send time    |
+| command | Gear type (1: NEUTRAL, 2: DRIVE, 20: REVERSE) |
 
 ### `/vehicle/status/gear_status`
 
 | Name   | Description           |
-| ------ | --------------------- |
+| ------ | ---------------------- |
 | stamp  | Data acquisition time |
 | report | Gear type             |
 
-### `/sensing/gnss/pose_with_covariance`
+### `/sensing/gnss/nav_sat_fix`
 
-| Name                  | Description                         |
-| --------------------- | ----------------------------------- |
-| header.stamp          | Data acquisition time               |
-| header.frame_id       | Frame ID (`map`)                    |
-| pose.pose.position    | Vehicle position (origin of `base_link`) |
-| pose.pose.orientation | Unused                              |
-| pose.covariance       | Position accuracy                   |
+Positioning information from the GNSS sensor. The `racing_kart_gnss_poser` node converts the NavSatFix message into a pose in the vehicle coordinate system.
+
+| Name                  | Description                       |
+| --------------------- | ---------------------------------- |
+| header.stamp          | Data acquisition time             |
+| header.frame_id       | Frame ID                          |
+| latitude              | Latitude (deg)                    |
+| longitude             | Longitude (deg)                   |
+| altitude              | Altitude (m)                      |
+| position_covariance   | Position covariance               |
 
 ### `/sensing/imu/imu_raw`
 
 | Name                | Description             |
-| ------------------- | ----------------------- |
+| ------------------- | ------------------------ |
 | header.stamp        | Data acquisition time   |
 | header.frame_id     | Frame ID (`imu_link`)   |
 | orientation         | Orientation             |
 | angular_velocity    | Angular velocity        |
 | linear_acceleration | Linear acceleration     |
 
+### `/sensing/lidar/scan`
+
+Scan data from the 2D LiDAR sensor.
+
+| Name                | Description                    |
+| ------------------- | -------------------------------- |
+| header.stamp        | Data acquisition time          |
+| header.frame_id     | Frame ID                       |
+| angle_min           | Scan start angle (rad)         |
+| angle_max           | Scan end angle (rad)           |
+| angle_increment     | Angular resolution (rad)       |
+| range_min           | Minimum range (m)              |
+| range_max           | Maximum range (m) (max 30 m)   |
+| ranges              | Range data array (1080 points) |
+
+### `/sensing/camera/image_raw`
+
+RGB image data from the camera.
+
+| Name                | Description            |
+| ------------------- | ------------------------ |
+| header.stamp        | Data acquisition time  |
+| header.frame_id     | Frame ID               |
+| height              | Image height (px)      |
+| width               | Image width (px)       |
+| encoding            | Encoding format        |
+| data                | Image data             |
+
+### `/sensing/camera/camera_info`
+
+Intrinsic parameters of the camera.
+
+| Name                | Description            |
+| ------------------- | ------------------------ |
+| header.stamp        | Data acquisition time  |
+| header.frame_id     | Frame ID               |
+| height              | Image height (px)      |
+| width               | Image width (px)       |
+| k                   | Camera intrinsic matrix (3x3) |
+| d                   | Distortion coefficients |
+
+### `/v2x/vehicle_positions`
+
+Positions of the vehicles shared via V2X. AWSIM publishes it directly in each vehicle's domain. It is enabled/disabled with the `--v2x` launch option, and a vehicle whose GNSS is disabled with `--gnss off` also disappears from this array ([Simulator](./simulator.en.md)).
+
+`v2x_msgs/msg/V2XVehiclePositionArray`
+
+| Name       | Description                                 |
+| ---------- | --------------------------------------------- |
+| header     | Header of the whole array                   |
+| vehicles[] | Array of `v2x_msgs/msg/V2XVehiclePosition`  |
+
+`v2x_msgs/msg/V2XVehiclePosition`
+
+| Name         | Description                                                   |
+| ------------ | ----------------------------------------------------------------- |
+| header.stamp | Observation time                                              |
+| header.frame_id | Coordinate frame (e.g. `map`)                              |
+| vehicle_id   | ID identifying the vehicle (e.g. `d1`-`d4`)                   |
+| position     | Position of the vehicle (`geometry_msgs/Point`, in the `header.frame_id` frame) |
+| covariance   | Position uncertainty (`geometry_msgs/Vector3`, standard deviation [m] along x/y/z) |
+
+- The message contains position only. It has no orientation or velocity fields, so the heading and speed of other vehicles must be estimated from a sequence of positions.
+- A transmission delay that imitates the real vehicle is added (100-200 ms per vehicle, mean 150 ms, standard deviation 25 ms). See [Simulator](./simulator.en.md) for details.
+
 ### `/aichallenge/objects`
 
-| Name            | Description               |
-| --------------- | ------------------------- |
-| data[N * 4 + 0] | X coordinate of Nth object |
-| data[N * 4 + 1] | Y coordinate of Nth object |
-| data[N * 4 + 2] | Z coordinate of Nth object |
-| data[N * 4 + 3] | Radius of Nth object      |
+Obstacle information on the course. `std_msgs/msg/Float64MultiArray`, with 4 values per object.
 
-### `/aichallenge/pitstop/area`
+| Name            | Description                   |
+| --------------- | -------------------------------- |
+| data[N * 4 + 0] | X coordinate of the Nth object |
+| data[N * 4 + 1] | Y coordinate of the Nth object |
+| data[N * 4 + 2] | Z coordinate of the Nth object |
+| data[N * 4 + 3] | Radius of the Nth object       |
 
-| Name    | Description                                   |
-| ------- | --------------------------------------------- |
-| data[0] | X position of Pit Stop Area                   |
-| data[1] | Y position of Pit Stop Area                   |
-| data[2] | Z position of Pit Stop Area                   |
-| data[3] | X quaternion of Pit Stop Area                 |
-| data[4] | Y quaternion of Pit Stop Area                 |
-| data[5] | Z quaternion of Pit Stop Area                 |
-| data[6] | W quaternion of Pit Stop Area                 |
-| data[7] | X size of of Pit Stop Area                    |
-| data[8] | Y size of of Pit Stop Area                    |
+### `/awsim/status`
 
-### `/aichallenge/pitstop/condition`
+A topic for obtaining various simulation states. It is of type `Float32MultiArray` and has the following 7 fields.
 
-| Name | Description             |
-| ---- | ----------------------- |
-| data | Current condition value |
+| Index | Value           | Description                                    |
+| ----- | ---------------- | ------------------------------------------------ |
+| 0     | sessionTime     | Remaining session time (seconds, counting down) |
+| 1     | lapCount        | Current lap count                              |
+| 2     | thisLapTime     | Current lap time (seconds)                     |
+| 3     | section         | Current section number                         |
+| 4     | timeScale       | Simulation time scale                          |
+| 5     | boostRemaining  | Remaining number of boosts                     |
+| 6     | isBoosting      | Boosting flag (1.0 = boosting / 0.0)           |
 
-### `/aichallenge/pitstop/status`
+### `/awsim/state`
 
-| Name | Description                           |
-| ---- | ------------------------------------- |
-| data | Number of seconds a pit stop is valid |
+A string topic that indicates the simulation state of each vehicle. The following state values are published.
+
+| State value | Description                              |
+| ----------- | ------------------------------------------ |
+| Spawned     | The vehicle has been spawned             |
+| Grounded    | The vehicle has touched the ground       |
+| Ready       | The vehicle is ready                     |
+| Start       | Driving has started                      |
+| Finish      | Driving has finished (reached the specified number of laps) |
+
+### `/awsim/cmd`
+
+A topic for sending commands to AWSIM. It is of type `Float32MultiArray` and has the following field.
+
+| Index | Value        | Description                                          |
+| ----- | ------------- | ------------------------------------------------------ |
+| 0     | boostCommand | Raising it to `1.0` or higher activates the turbo boost. To activate it again, set it back to `0.0` once and then raise it to `1.0` again. |
+
+### `/admin/awsim/state`
+
+An admin topic that indicates the state of the whole simulation (domain 0).
+
+| State value | Description                        |
+| ----------- | ------------------------------------ |
+| SelectMode  | Mode selection screen              |
+| PlayStart   | Play started                       |
+| Ready       | Ready                              |
+| WaitStart   | Waiting for start                  |
+| Start       | Simulation started                 |
+| Finish      | Simulation finished                |
+| LapComplete | Lap completed                      |
+| FinishAll   | All vehicles finished              |
+| Terminate   | Termination processing             |

--- a/docs/specifications/interface.ja.md
+++ b/docs/specifications/interface.ja.md
@@ -24,6 +24,7 @@ sequenceDiagram
     AWSIM->>Autoware: /sensing/gnss/nav_sat_fix
     AWSIM->>Autoware: /sensing/imu/imu_raw
     AWSIM->>Autoware: /sensing/lidar/scan
+    AWSIM->>Autoware: /v2x/vehicle_positions
 
     Note over AWSIM,Autoware: 制御コマンド（AWSIM ← Autoware）
     Autoware->>AWSIM: /control/command/control_cmd
@@ -59,6 +60,12 @@ sequenceDiagram
 | Publisher | `/sensing/camera/image_raw`          | `sensor_msgs/msg/Image`                       |
 | Publisher | `/sensing/camera/camera_info`        | `sensor_msgs/msg/CameraInfo`                  |
 
+### V2X
+
+| Interface | Name                                 | Type                                          |
+| --------- | ------------------------------------ | ---------------------------------------------- |
+| Publisher | `/v2x/vehicle_positions`             | `v2x_msgs/msg/V2XVehiclePositionArray`        |
+
 ### シミュレーション管理
 
 AWSIMが各車両のドメイン（N=1〜4）で直接やり取りするトピックです。
@@ -87,6 +94,7 @@ AWSIMの全体管理に使用されるトピックです。通常の開発では
 - **制御コマンド**: [`control_cmd`](#controlcommandcontrol_cmd) / [`actuation_cmd`](#controlcommandactuation_cmd)
 - **車両ステータス**: [`actuation_status`](#vehiclestatusactuation_status) / [`velocity_status`](#vehiclestatusvelocity_status) / [`steering_status`](#vehiclestatussteering_status) / [`gear_status`](#vehiclestatusgear_status)
 - **センサ**: [`gnss`](#sensinggnssnav_sat_fix) / [`imu`](#sensingimuimu_raw) / [`lidar`](#sensinglidarscan) / [`camera`](#sensingcameraimage_raw)
+- **V2X**: [`v2x/vehicle_positions`](#v2xvehicle_positions)
 - **シミュレーション**: [`awsim/status`](#awsimstatus) / [`awsim/state`](#awsimstate) / [`awsim/cmd`](#awsimcmd) / [`admin/awsim/state`](#adminawsimstate)
 
 ### `/control/command/control_cmd`
@@ -220,6 +228,41 @@ GNSSセンサからの測位情報です。`racing_kart_gnss_poser`ノードがN
 | width               | 画像の幅（px）         |
 | k                   | カメラ内部行列（3x3）  |
 | d                   | 歪み係数               |
+
+### `/v2x/vehicle_positions`
+
+V2Xで共有される各車両の位置情報です。AWSIMが各車両のドメインに直接publishします。起動オプション `--v2x` で有効/無効を切り替えられ、`--gnss off` の車両はこの配列からも消えます（[シミュレーター](./simulator.ja.md)）。
+
+`v2x_msgs/msg/V2XVehiclePositionArray`
+
+| Name       | Description                                 |
+| ---------- | -------------------------------------------- |
+| header     | 配列全体のヘッダ                            |
+| vehicles[] | `v2x_msgs/msg/V2XVehiclePosition` の配列    |
+
+`v2x_msgs/msg/V2XVehiclePosition`
+
+| Name         | Description                                                   |
+| ------------ | --------------------------------------------------------------- |
+| header.stamp | 観測時刻                                                      |
+| header.frame_id | 座標フレーム（例: `map`）                                  |
+| vehicle_id   | 車両を識別するID（例: `d1`〜`d4`）                            |
+| position     | 車両の位置（`geometry_msgs/Point`、`header.frame_id` 系）     |
+| covariance   | 位置の不確実性（`geometry_msgs/Vector3`、x/y/z軸の標準偏差 [m]） |
+
+- 含まれるのは位置のみです。姿勢・速度のフィールドはないため、他車の向きや速度は位置の時系列から推定する必要があります。
+- 実車を模した伝送遅延（車両ごとに100〜200 ms、平均150 ms・標準偏差25 ms）が入っています。詳細は[シミュレーター](./simulator.ja.md)を参照してください。
+
+### `/aichallenge/objects`
+
+コース上の障害物情報です。`std_msgs/msg/Float64MultiArray` 型で、1物体あたり4要素です。
+
+| Name            | Description          |
+| --------------- | --------------------- |
+| data[N * 4 + 0] | N番目の物体のX座標   |
+| data[N * 4 + 1] | N番目の物体のY座標   |
+| data[N * 4 + 2] | N番目の物体のZ座標   |
+| data[N * 4 + 3] | N番目の物体の半径    |
 
 ### `/awsim/status`
 


### PR DESCRIPTION
## 日本語

1. 英語版 `specifications/interface.en.md` が2024年版のままで、`/sensing/gnss/pose_with_covariance`（AWSIMは `/sensing/gnss/nav_sat_fix` を配信）、`/aichallenge/pitstop/*`（2026年は未実装）、`/control/control_mode_request` サービス（現行は `/awsim/control_mode_request_topic` のBoolトピック）など、現行環境に存在しないI/Fが記載されていました。現行の `interface.ja.md` を忠実に英訳して置き換えます。

2. S2R部門で他車情報を得る唯一の手段である `/v2x/vehicle_positions`（`v2x_msgs/msg/V2XVehiclePositionArray`）がどちらの言語にも記載されていなかったため、`v2x_msgs/msg/*.msg` の定義に基づきフィールド表を日英両方に追加しました（位置のみで姿勢・速度は含まれないこと、伝送遅延はシミュレーター仕様への参照）。

3. `/aichallenge/objects` について: この節はaichallenge-racingkart devのソースコード（`multi_purpose_mpc_ros/multi_purpose_mpc_ros/path_constraints_provider.py:96` と `aichallenge_system_launch/script/object_marker.py:14` にあるサブスクライバ、および4要素ストライドのパーサ実装）に基づいて記載しています。**`ros2 topic echo` による実配信の確認は行っていません**（実行可能なROS環境がこの作業環境にないため）。パブリッシャ自体はAWSIMバイナリ内にあり、ソースからは検証できません。確認したのはメッセージ型とフィールド名がdevのサブスクライバ実装と一致することのみで、実際にこのトピックが2026年のAWSIMから配信されているかどうかは未検証です。レビュアーへの確認依頼: 可能であれば `make dev` 上で `ros2 topic echo /aichallenge/objects --once` を実行して配信を確認してください。配信されない場合はこの節を両言語から削除してください。

確認: `mkdocs build` のWARNING数は変化なし（19 -> 19、差分なし）。トピック集合はJA/EN間で完全一致（`grep -o` での差分は空）。pre-commit（markdownlint / prettier / Markdown Link Check 等）はすべてPassed。

## English

1. `specifications/interface.en.md` was still the 2024 page. It listed `/sensing/gnss/pose_with_covariance` (AWSIM publishes `/sensing/gnss/nav_sat_fix`), `/aichallenge/pitstop/*` (not implemented in 2026) and a `/control/control_mode_request` service (now the `/awsim/control_mode_request_topic` Bool topic). This PR replaces it with a faithful translation of the current `interface.ja.md`.

2. `/v2x/vehicle_positions` (`v2x_msgs/msg/V2XVehiclePositionArray`), the only source of opponent information in the S2R class, was undocumented in both languages. This PR adds a field table to JA and EN, derived from `v2x_msgs/msg/*.msg`: position only, no heading/velocity; latency is cross-referenced to the Simulator page.

3. On `/aichallenge/objects`: this section is based on reading the aichallenge-racingkart dev source (the subscribers at `multi_purpose_mpc_ros/multi_purpose_mpc_ros/path_constraints_provider.py:96` and `aichallenge_system_launch/script/object_marker.py:14`, plus the stride-4 array parser they implement). **This was not verified with `ros2 topic echo`**, since no running ROS environment was available in the environment this PR was prepared in. The publisher itself lives inside the AWSIM binary and cannot be confirmed from source at all. What was checked is that the message type and field layout match the dev subscriber code; whether this topic is actually published by the 2026 AWSIM build was not executed or confirmed. Request to reviewer: if possible, run `ros2 topic echo /aichallenge/objects --once` under `make dev` to confirm it is published before merging. If it does not appear, please drop this section from both languages.

Checked: `mkdocs build` warning count unchanged (19 -> 19, empty sorted diff). Topic name sets in JA and EN match exactly (`grep -o` diff is empty). Pre-commit (markdownlint / prettier / Markdown Link Check, etc.) all passed.

---
Team Hayes (Ajayaditya Lokchandra, Nithisha Venkatesh)

本PRはAIコーディング支援を用いて作成し、上記の確認手順で検証しました。 / Prepared with AI coding assistance and verified with the checks above.
