### PR TITLE
docs(competition): resync ai-class.en.md with the current Japanese rules

### DIFF
--- a/docs/competition/ai-class.en.md
+++ b/docs/competition/ai-class.en.md
@@ -36,7 +36,7 @@ Same as the [Sim to Real Division](./sw-class.en.md).
 - Gear Status
 
 !!! warning "About available sensors"
-    Because End to End AI approaches are emphasized, sensors that could be used in the Sim to Real Division, such as GNSS, cannot be used.
+    Because End to End AI approaches are emphasized, sensors used in the Sim to Real Division that are not listed above, such as GNSS, cannot be used.
 
 ### Safety Gates
 

--- a/docs/competition/ai-class.en.md
+++ b/docs/competition/ai-class.en.md
@@ -1,42 +1,85 @@
-# End to End AI Division
+# End to End Division Rules
 
-## AI Division Overview
+!!! warning "WIP"
+    Some rules are not yet finalized and may be updated.
 
-The AI Division progresses from qualifying to finals as follows:
+## End to End Division Overview
+
+The End to End AI Division progresses from qualifying to the finals as follows.
 
 | Item | Schedule | Content | Participating Teams |
 | --- | --- | --- | --- |
-| AI Division Qualifying | Around August | Submit presentation documents + driving video | Applicants |
-| AI Division SIM Finals | September 19 | Race in simulation environment at the finals venue with participant-brought PCs | Top 8–16 teams from AI Qualifying |
+| End to End Division Qualifying | July 1 – September 1 | Submit presentation documents and a driving video. ([Submission form](https://forms.office.com/pages/responsepage.aspx?id=NVLCok7DvEuOMQxVDG-yrJTP427xWZBKkcBQTu6n-vxUMTU5SkpIRFQ3UDRWUk9WNTBLVjUwR0lUNy4u&route=shorturl)) | Applicants |
+| SIM Finals Preparation | September 18 | Operation check and practice runs in the same environment as on the SIM Finals day | Finalist teams that wish to take part |
+| End to End Division SIM Finals | September 19 | Race in the simulation environment at the finals venue | Top 16 teams from E2E AI Qualifying |
 
 !!! warning
-    - Teams participating in the AI Division are also required to participate in the SW Division.
-    - There is no real vehicle race in the AI Division.
+    - Teams participating in the End to End Division must also participate in the Sim to Real Division.
+    - There is no real vehicle race in the End to End Division.
 
-## AI Division Qualifying Rules
+## Common Rules for the End to End Division
 
-- In the AI Division qualifying, the organizers will evaluate the teams' approaches.
-- Teams will submit presentation documents and driving videos, which will be scored by judges.
-- Further details about the evaluation will be announced separately.
+### Race Format
 
-## AI Division SIM Finals Rules
+- Vehicles race on AWSIM in an environment that replicates the City Circuit Tokyo Bay (CCTB) course.
 
-The basic rules are the same as the SW Division SIM Finals, with the following differences:
+### Speed and Penalties
 
-### Execution Environment
-
-- Teams will run their code on their own PCs. GPU use and access to external servers are also permitted.
-- Teams' 4 PCs will be connected to the AWSIM PC provided by the organizers for the competition.
+Same as the [Sim to Real Division](./sw-class.en.md).
 
 ### Available Sensors
 
 - Camera
 - LiDAR
+- Steer Angle
 - Wheel Odometry
+- Gear Status
 
-!!! warning "About Available Sensors"
-    Because End to End AI approaches are emphasized, sensors available in the SW Division such as GNSS cannot be used.
+!!! warning "About available sensors"
+    Because End to End AI approaches are emphasized, sensors that could be used in the Sim to Real Division, such as GNSS, cannot be used.
 
-### Evaluation Method
+### Safety Gates
 
-The final evaluation will be determined by a combined score of the qualifying evaluation results and the finals race results.
+Same as the [Sim to Real Division](./sw-class.en.md).
+
+### Prohibited Actions
+
+Same as the [Sim to Real Division](./sw-class.en.md).
+
+## End to End Division SIM Qualifying
+
+- In the End to End Division qualifying, the teams' approaches are reviewed.
+- Teams submit presentation documents and a driving video, which are scored by judges.
+- [Submission form](https://forms.office.com/pages/responsepage.aspx?id=NVLCok7DvEuOMQxVDG-yrJTP427xWZBKkcBQTu6n-vxUMTU5SkpIRFQ3UDRWUk9WNTBLVjUwR0lUNy4u&route=shorturl)
+
+![e2e_submit](./images/e2e_submit.png)
+
+## End to End Division SIM Finals { #semifinal }
+
+### Ranking System
+
+- Races are held with 4 vehicles simultaneously. The race is 6 laps.
+- Selection round
+    - 4 races are held, with general and student teams mixed.
+    - Starting positions are determined by the qualifying review results.
+    - The 4 teams that advance to the final race are selected by a combined score of the document review, presentation and race results.
+        - Because this division emphasizes the approach, the document review and presentation account for 70% and the race results for 30%. Therefore, a team with a top race result does not necessarily advance to the final.
+        - The breakdown of the scores is not disclosed, and inquiries about it cannot be answered.
+- Final race
+    - A race is held with the 4 teams that advanced from the selection round.
+    - Starting positions are determined by the selection round ranking.
+    - The final ranking is determined solely by the finishing order of the race.
+
+![e2e_tournament](./images/e2e_sim_tournament.png)
+
+### Rules
+
+- The basic rules follow the common rules above.
+- Races start forcibly at the scheduled start time. A team whose setup is not complete either continues working and aims to join mid-race, or retires.
+- If a vehicle gets stuck because of a crash or behaves unexpectedly, the organizers will not help it recover.
+- Participants may perform any operation from their own terminal and RViz (but cannot operate the AWSIM screen). The expected operations are:
+    - Restarting Autoware
+    - Re-setting the self-position (localization)
+    - Moving the vehicle by manual driving when it is stuck
+    - Switching gear and issuing turbo commands with the `ros2 topic` command
+- However, you must report to the organizers before operating. Frequent use of manual driving is prohibited. Operations that affect anything other than your own ROS_DOMAIN_ID are also prohibited.


### PR DESCRIPTION
## 概要
`ai-class.en.md` が 2026-07 時点のままで、#74 で更新された日本語版と食い違っていました。主な点は次のとおりです。
- 予選期間「Around August」（正：7月1日〜9月1日）
- 決勝進出「上位8〜16」（正：16）
- 最終順位「予選評価と決勝走行の合算」（正：選抜戦は書類・プレゼン70%/走行30%、決勝戦は完走順のみ）
- 使用可能センサーに Steer Angle / Gear Status なし

SIM決勝のルール（復帰サポートなし・許可される操作・事前申告）と `{ #semifinal }` アンカーもありませんでした。

## 変更内容
現行の `ai-class.ja.md` を忠実に英訳して置き換えました。アンカー・画像・提出フォームURLは維持しています。
英語版にのみあった「GPU・外部サーバー使用可」の記述は現行の日本語ページに無いため削除しています。持参PC構成は SIM決勝ページに記載があります。

`ai-class.ja.md` にはすでに `{ #semifinal }` アンカーが存在していたため、日本語側の変更はありません。

## 確認
`mkdocs build` で本ファイル起因の警告はありません。

Team Hayes（非日本語話者チーム）より。誤訳があればご指摘ください。

## Summary
`ai-class.en.md` was still the July 2026 text and contradicted the Japanese page updated in #74:
- Qualifying "around August" (actually July 1 to September 1).
- "Top 8-16" finalists (actually 16).
- Final result "combined qualifying + race score". Actually: a selection round at 70% documents/presentation and 30% race, then a final decided by finishing order only.
- Missing sensors Steer Angle / Gear Status.

It also lacked the SIM Finals rules (no organiser recovery, allowed operations, report before operating) and the `{ #semifinal }` anchor.

## Changes
Full replacement with a faithful translation of the current `ai-class.ja.md`; the anchor, images and the form URL are kept. The EN-only line "GPU use and access to external servers are permitted" is dropped because no current Japanese page states it. The bring-your-own-PC setup is described on the SIM Finals page.

`ai-class.ja.md` already had the `{ #semifinal }` anchor before this change, so no Japanese-side edit was needed.

## Checks
Non-strict `mkdocs build`: warnings before and after are identical, 19 lines in both cases; no warning mentions `ai-class` in either build.

Before (19 lines, baseline):
```
WARNING -  Doc file 'competition/kart-finals.ja.md' contains a link './sw-class.ja.md#final-abst', but the target 'competition/sw-class.ja.md' is not found among documentation files.
WARNING -  Doc file 'competition/sim-finals-pc.ja.md' contains a link '../specifications/hardware.ja.md', but the target 'specifications/hardware.ja.md' is not found among documentation files.
WARNING -  Doc file 'competition/sim-finals.ja.md' contains a link './ai-class.ja.md#semifinal', but the target 'competition/ai-class.ja.md' is not found among documentation files.
WARNING -  Doc file 'competition/sim-finals.ja.md' contains a link './sw-class.ja.md#overtake-lane', but the target 'competition/sw-class.ja.md' is not found among documentation files.
WARNING -  Doc file 'competition/sim-finals.ja.md' contains a link './sw-class.ja.md#semifinal', but the target 'competition/sw-class.ja.md' is not found among documentation files.
WARNING -  Doc file 'competition/submission.en.md' contains a link '../specifications/submission-contract.en.md', but the target 'specifications/submission-contract.en.md' is not found among documentation files.
WARNING -  Doc file 'competition/submission.ja.md' contains a link '../specifications/submission-contract.ja.md', but the target 'specifications/submission-contract.ja.md' is not found among documentation files.
WARNING -  Doc file 'ml_sample/pilot_net.md' contains a link '../setup/gpu-simulation.ja.md#env-check', but the target 'setup/gpu-simulation.ja.md' is not found among documentation files.
WARNING -  Doc file 'ml_sample/pilot_net.md' contains a link '../setup/introduction.ja.md', but the target 'setup/introduction.ja.md' is not found among documentation files.
WARNING -  Doc file 'ml_sample/soft_actor_critic.md' contains a link '../setup/introduction.ja.md', but the target 'setup/introduction.ja.md' is not found among documentation files.
WARNING -  Doc file 'ml_sample/tiny_lidar_net.md' contains a link '../setup/gpu-simulation.ja.md#env-check', but the target 'setup/gpu-simulation.ja.md' is not found among documentation files.
WARNING -  Doc file 'ml_sample/tiny_lidar_net.md' contains a link '../setup/introduction.ja.md', but the target 'setup/introduction.ja.md' is not found among documentation files.
WARNING -  Doc file 'ml_sample/tiny_lidar_net.md' contains a link '../specifications/simulator.ja.md', but the target 'specifications/simulator.ja.md' is not found among documentation files.
WARNING -  Doc file 'vehicle/operation.ja.md' contains a link '../competition/sw-class.ja.md#final-abst', but the target 'competition/sw-class.ja.md' is not found among documentation files.
WARNING -  Doc file 'vehicle/operation.ja.md' contains a link '../competition/sw-class.ja.md#final-rule', but the target 'competition/sw-class.ja.md' is not found among documentation files.
WARNING -  Doc file 'vehicle/operation.ja.md' contains a link '../competition/sw-class.ja.md#safety-gate', but the target 'competition/sw-class.ja.md' is not found among documentation files.
WARNING -  Doc file 'vehicle/operation.ja.md' contains a link '../development/development-guide.ja.md#safety-gate', but the target 'development/development-guide.ja.md' is not found among documentation files.
WARNING -  mkdocs_static_i18n: mkdocs-material language switcher contextual link is not compatible with theme.features = navigation.instant
WARNING -  mkdocs_static_i18n: mkdocs-material language switcher contextual link is not compatible with theme.features = navigation.instant
```

After: byte-identical to the above, 19 lines, no new warnings, none removed.

Note: the `competition/sim-finals.ja.md` warning about `./ai-class.ja.md#semifinal` was already present in the baseline before this change, because `ai-class.ja.md` already carried the `{ #semifinal }` anchor. It is a pre-existing `mkdocs-static-i18n` quirk where the linked JA target file is not recognized as a doc file for link-checking purposes (independent of the anchor's existence), not something this PR's `.en.md` change touches or fixes.

`pre-commit run --files docs/competition/ai-class.en.md`: all hooks passed (check-merge-conflict, detect-private-key, end-of-file-fixer, mixed-line-ending, trailing-whitespace, markdownlint, prettier, markdown-link-check).

---
Team Hayes (Ajayaditya Lokchandra, Nithisha Venkatesh)

本PRはAIコーディング支援を用いて作成し、上記の確認手順で検証しました。 / Prepared with AI coding assistance and verified with the checks above.
