### PR TITLE
docs(development): remove a deleted script and a non-existent make target from the EN guides

### DIFF
--- a/docs/development/commands.en.md
+++ b/docs/development/commands.en.md
@@ -8,14 +8,16 @@ Performs environment checks and initial setup.
 |---|---|
 | `./setup.bash` | Checks the environment and shows the next steps (same as `doctor`) |
 | `./setup.bash doctor` | Checks the environment and prints a summary of the next steps |
-| `./setup.bash bootstrap` | Installs Docker, clones the repository, and runs setup in one shot (for new machines) |
-| `./setup.bash pull image` | Pulls the Autoware base image via `docker pull` |
+| `./setup.bash bootstrap` | Installs Docker, clones the repository, and runs setup in one go (for setting up a new PC) |
+| `./setup.bash pull image` | Pulls the Autoware base image with `docker pull` |
 | `./setup.bash download awsim` | Downloads and extracts `AWSIM.zip` |
 | `./setup.bash env` | Creates `.env` from `.env.example` |
+| `./setup.bash network tune` | Persists the host settings for DDS (`rmem_max` and loopback multicast; requires sudo) |
+| `./setup.bash network if [name]` | Adds a network interface to `cyclonedds.xml`; without a name, removes all interfaces that were added by this script |
 
 ## create_submit_file.bash
 
-Compresses `aichallenge_submit/` into a submission archive. Output: `submit/aichallenge_submit.tar.gz`.
+Compresses `aichallenge_submit/` into a submission file. The output is `submit/aichallenge_submit.tar.gz`.
 
 ```bash
 ./create_submit_file.bash
@@ -28,19 +30,8 @@ Builds Docker images. Build logs are saved under `output/docker/`.
 | Command | Description |
 |---|---|
 | `./docker_build.sh dev` | Builds the development image (`aichallenge-2025-dev`) |
-| `./docker_build.sh eval` | Builds the evaluation image (`aichallenge-2025-eval`) with the submission archive embedded — always a full rebuild with `--no-cache` |
-| `./docker_build.sh eval --submit <path>` | Builds the evaluation image using the submission archive at `<path>` (default: `submit/aichallenge_submit.tar.gz`) |
-
-## run_parallel_submissions.bash
-
-Evaluates multiple submission archives simultaneously. Accepts 1–4 archives (`aichallenge_submit.tar.gz`) and runs each on a separate Domain ID (`d1`–`d4`).
-
-| Command | Description |
-|---|---|
-| `./run_parallel_submissions.bash --submit <tar1> [<tar2> ...]` | Evaluates 1–4 submissions in parallel |
-| `./run_parallel_submissions.bash down` | Stops all running containers |
-
-Logs and results are saved under `output/<timestamp>/d<domain_id>/`.
+| `./docker_build.sh eval` | Builds the evaluation image with the submission file embedded (`aichallenge-2025-eval`); always a full build with `--no-cache` |
+| `./docker_build.sh eval --submit <path>` | Builds using the submission file at `<path>` (default: `submit/aichallenge_submit.tar.gz`) |
 
 ## make commands
 
@@ -50,33 +41,50 @@ Logs and results are saved under `output/<timestamp>/d<domain_id>/`.
 |---|---|
 | `make autoware-build` | Builds the ROS workspace (`aichallenge/workspace/`) |
 | `make dev` | Starts AWSIM + Autoware for development (shorthand for `simulator` + `autoware-simulator`) |
+| `make dev2` | Starts AWSIM + 2 × Autoware for development |
+| `make dev3` | Starts AWSIM + 3 × Autoware for development |
+| `make dev4` | Starts AWSIM + 4 × Autoware for development |
+| `make e2e` | Starts AWSIM + Autoware for End to End practice (with 2 NPCs; also use this to check before submitting) |
 | `make eval` | Starts AWSIM + Autoware for evaluation |
+| `make gate1` | Starts the safety gate scenario (obstacle stop) |
+| `make gate2` | Starts the safety gate scenario (overtaking) |
+| `make gate3` | Starts the safety gate scenario (lane keeping) |
 | `make down` | Stops and removes all running containers |
 | `make down_all` | Force-removes all Docker containers on the host |
 | `make ps` | Lists running containers |
+| `make autoware-attach` | Opens bash in an existing container |
+| `make autoware-bash` | Opens bash in a new container |
 
 ### Starting individual services
 
 | Command | Description |
 |---|---|
 | `make simulator` | Starts AWSIM only |
-| `make autoware-simulator` | Starts Autoware only (simulation mode) |
-| `make autoware-vehicle` | Starts Autoware only (real vehicle mode) |
-| `make driver` | Starts the vehicle interface (`racing_kart_interface`) |
-| `make zenoh` | Starts Zenoh (remote vehicle connection) |
+| `make simulator-dev2` | Starts AWSIM only (for 2 vehicles) |
+| `make simulator-dev3` | Starts AWSIM only (for 3 vehicles) |
+| `make simulator-dev4` | Starts AWSIM only (for 4 vehicles) |
+| `make simulator-e2e-final` | Starts AWSIM only (End to End finals settings) |
+| `make simulator-s2r-final` | Starts AWSIM only (Sim to Real finals settings) |
+| `make autoware-simulator` | Starts Autoware only (for the simulator) |
+| `make autoware-vehicle` | Starts Autoware only (for the real vehicle) |
+| `make driver` | Starts the real-vehicle interface (`racing_kart_interface`) |
+| `make zenoh` | Starts Zenoh (remote connection to the real vehicle) |
 | `make rviz2` | Starts RViz2 |
-| `make autoware-driver-zenoh` | Starts `driver` + `autoware` + `zenoh` together (real vehicle use) |
+| `make autoware-driver-zenoh` | Starts `driver` + `autoware` + `zenoh` together (for the real vehicle) |
+
+`make simulator-<mode>` runs `aichallenge/simulator_scripts/<mode>.sh`. For the list of modes and their settings, see [Simulator launch modes](../specifications/simulator.en.md#launch-modes).
 
 ### Sending commands
 
 | Command | Description |
 |---|---|
-| `make autoware-request-initialpose` | Sends a request to set the initial pose |
-| `make autoware-request-control` | Sends a request to enable autonomous driving control mode |
-| `make simulator-reset` | Resets the simulator |
+| `make autoware-request-control` | Sends the control mode request for autonomous driving |
+| `make autoware-request-initialpose` | Sends the request to set the initial pose |
+| `make awsim-request-reset` | Resets the simulator |
+| `make awsim-request-start` | Sends the race start command to the simulator |
 
 ### Other
 
 | Command | Description |
 |---|---|
-| `make download` | Downloads submission data (optionally specify `SUBMISSION_ID=<id>`) |
+| `make download` | Downloads submission data (can be specified with `SUBMISSION_ID=<id>`) |

--- a/docs/development/development-guide.en.md
+++ b/docs/development/development-guide.en.md
@@ -1,6 +1,8 @@
 # Development Guide
 
-This page covers procedures only. For details on individual commands and the environment structure, see [Environment Overview](environment.en.md) and [Command Reference](commands.en.md). Once you understand the development workflow, head to [Development Ideas](development-ideas.en.md) and start building your own solution.
+This page explains how to proceed with development in the AI Challenge and the main commands. For details on each command and on the environment, see [Environment Overview](environment.en.md) and [Command Reference](commands.en.md).
+
+Once you understand how development works here, use [Development Ideas](development-ideas.en.md) as a reference and move on to your own development.
 
 ## Development Cycle
 
@@ -8,20 +10,20 @@ Development follows this cycle:
 
 1. **Edit code** — Modify files under `aichallenge/workspace/src/aichallenge_submit/`
 2. **Build** — Build the ROS workspace with `make autoware-build`
-3. **Test** — Start the simulator with `make dev` and check behavior
-4. **Local Evaluation** — Run `make eval` for quantitative evaluation and check results under `output/latest/`
+3. **Check behavior**: Start the simulator with `make dev` and check how the vehicle behaves
+4. **Local evaluation**: Run a quantitative evaluation with `make eval` and check the results in `output/latest/`
 5. **Submit** — Upload following the [submission instructions](../competition/submission.en.md)
 
-## Development and Debugging
+### Development and Debugging Steps
 
-- The development Docker image is built when you run `setup.bash`. Re-run it as needed when updating the environment.
-- The basic loop is: edit code → build → verify behavior, repeated as needed.
+- Basically, you develop by repeating code changes, builds, and behavior checks with the commands below.
+- The development Docker image is already created when you run `setup.bash`. Re-run it as needed, for example when the environment is updated.
 
 ```bash
-# Build the development Docker image (first time, or when updating the environment)
+# Build the development Docker image (first time only, or when the environment is updated)
 ./docker_build.sh dev
 
-# Edit files under aichallenge/workspace/src/aichallenge_submit/
+# Edit the code under aichallenge/workspace/src/aichallenge_submit/
 
 # Build the workspace
 make autoware-build
@@ -29,23 +31,26 @@ make autoware-build
 # Start AWSIM + Autoware
 make dev
 
-# Verify behavior
+# Check the behavior
 
 # Stop AWSIM + Autoware
 make down
 ```
 
+!!! tip "How to stop"
+    Closing the RViz or AWSIM window does not stop them. Always stop with `make down` or `make down_all`.
+
 !!! tip "Checking and force-stopping containers"
-    Use `make ps` to list running containers. If a container cannot be stopped, use `make down_all` to force-remove all containers.
+    `make ps` lists the running containers. If a container cannot be stopped, force-stop it with `make down_all`.
 
-## Local Evaluation
+### Local Evaluation Steps { #local-evaluation }
 
-- After development, run a local evaluation.
-- The evaluation Docker image must be rebuilt each time. The workspace build is done automatically as part of the image build.
-- Execution stops automatically once the run completes.
+- Once you have developed something, run an evaluation in your local environment.
+- The evaluation Docker image must be built every time. The workspace is built automatically while the Docker image is being built.
+- The purpose of these steps is to confirm that your code runs without errors in an environment close to the actual evaluation environment. These steps run a single-vehicle time attack, whereas the competition itself is a multi-vehicle race.
 
 ```bash
-# Compress aichallenge_submit/ and create the submission archive
+# Compress the aichallenge_submit directory to create the submission file
 ./create_submit_file.bash
 
 # Build the evaluation Docker image
@@ -55,80 +60,79 @@ make down
 make eval
 ```
 
-## Local Evaluation (Multiple Vehicles)
+!!! warning "If `make eval` stays at `Waiting for at least 1 matching subscription(s)...`"
+    After starting the evaluation container, `make eval` runs `make awsim-request-start` (`ros2 topic pub -1 /admin/awsim/start ...` on domain 0). That command keeps waiting until AWSIM subscribes to `/admin/awsim/start`. The evaluation launch (`evaluation.launch.xml`) starts AWSIM and Autoware in the same launch, so if the launch of your submission fails (for example because a package in `aichallenge_submit` was not built or installed, or a dependency cannot be found), AWSIM is shut down with it and the terminal stays at this message.
 
-- Use `run_parallel_submissions.bash` to evaluate multiple vehicles at the same time.
-- Accepts 1–4 submission archives, each running on a separate Domain ID (`d1`–`d4`).
-- A separate evaluation Docker image is built for each archive.
+    Exit with `Ctrl+C`, run `make down`, and then check the following.
 
-```bash
-# Prepare the submission archives (example: 2 vehicles)
-./create_submit_file.bash  # your code → submit/aichallenge_submit.tar.gz
+    ```bash
+    # Latest run log (launch errors appear here)
+    less "$(ls -td output/2*/d1 | head -n 1)/autoware.log"
 
-# Prepare a rival vehicle archive (here we copy our own)
-cp submit/aichallenge_submit.tar.gz submit/other_submit.tar.gz
-
-# Run parallel evaluation with multiple archives
-./run_parallel_submissions.bash --submit submit/aichallenge_submit.tar.gz submit/other_submit.tar.gz
-```
+    # Check that your package is installed in the evaluation image (<package> is your package name)
+    docker run --rm aichallenge-2025-eval ls /aichallenge/workspace/install | grep <package>
+    ```
 
 ## Output
 
 ### Workspace Build Artifacts
 
-- `make autoware-build` outputs build artifacts to `aichallenge/workspace/build/`, which is mounted when running `make dev`.
-- For `make eval`, the workspace is built inside the Docker image during `./docker_build.sh eval` and the artifacts are stored in the image.
-- Check terminal output for build logs.
+- Artifacts of `make autoware-build` are written to `aichallenge/workspace/build` and are mounted and used when you run `make dev`.
+- For `make eval`, the workspace is also built when `./docker_build.sh eval` creates the Docker image, and the build artifacts are stored inside the image.
+- Check the terminal output for the build log.
 
 ### Execution Output
 
-Results are saved under `output/<timestamp>/d<domain_id>/`. The latest evaluation results (`make eval`) are also accessible via symlinks from `output/latest/d<domain_id>/`.
+Execution results are saved under `output/<timestamp>/d<domain_id>/`. The latest evaluation results (from `make eval`) can also be accessed through symbolic links in `output/latest/d<domain_id>/`.
 
 ```text
 output/
 ├── <timestamp>/
+│   ├── awsim.log                                 # AWSIM log (make dev)
 │   └── d1/
-│       ├── autoware.log                          # Autoware execution log
-│       ├── awsim.log                             # AWSIM execution log (make dev only)
+│       ├── autoware.log                          # Autoware log
 │       ├── ros/log/                              # Per-node logs
-│       ├── capture/                              # Capture video
+│       ├── capture/                              # Capture videos (cap-*.mp4)
 │       ├── rosbag2_autoware/                     # ROS bag files
-│       ├── d1-result-details.json                # Detailed drive data (make eval only)
+│       ├── d1-result-details.json                # Detailed driving data (make eval only)
 │       ├── result-summary.json                   # Lap time summary (make eval only)
 │       └── motion_analytics-<timestamp>.html     # Speed/acceleration visualization (make eval only)
-├── latest/                                       # Symlink to the latest evaluation result (make eval only)
-│   └── d1/                                       # Symlink to output/<timestamp>/d1/
-│       ├── autoware.log                          # Autoware execution log
-│       ├── capture/                              # Capture video
-│       ├── rosbag2_autoware/                     # ROS bag files (MCAP format)
-│       ├── d1-result-details.json                # Detailed drive data
+├── latest/                                       # A real directory whose entries are symlinks to the latest artifacts (make eval only)
+│   ├── docker_build.log                          # Latest docker_build.sh log
+│   └── d1/
+│       ├── autoware.log                          # Autoware log
+│       ├── capture.mp4                           # Capture video
+│       ├── rosbag2_autoware.mcap                 # ROS bag (MCAP format)
+│       ├── result-details.json                   # Detailed driving data (link to d1-result-details.json)
 │       ├── result-summary.json                   # Lap time summary
-│       └── motion_analytics-<timestamp>.html     # Speed/acceleration visualization
+│       └── motion_analytics.html                 # Interactive speed/acceleration visualization
 └── docker/
     └── <timestamp>-docker_build-<pid>.log        # docker_build.sh build log
 ```
 
-### Submission Archive Output
+### Submission File Output
 
-The archive created by `./create_submit_file.bash` is saved at `aichallenge-racingkart/submit/aichallenge_submit.tar.gz`.
+The file compressed by `./create_submit_file.bash` is saved at `aichallenge-racingkart/submit/aichallenge_submit.tar.gz`.
 
 ## Tips
 
-### Differences between `make dev` and `make eval`
+### Differences Between `make dev` and `make eval`
 
 | | `make dev` | `make eval` |
 | --- | --- | --- |
 | **Autoware image** | `aichallenge-2025-dev` | `aichallenge-2025-eval` |
-| **Workspace** | `./aichallenge` mounted | Baked into the image |
-| **Build** | `make autoware-build` reflects changes immediately | `./docker_build.sh eval` must be re-run |
-| **Laps** | 600 (effectively unlimited) | 6 |
-| **Timeout** | Effectively unlimited | 600 seconds |
-| **Termination** | Manual with `make down` | Stops automatically when the run completes |
-| **Output** | Logs only | Scores and drive data included |
+| **Workspace** | `./aichallenge` is mounted | Baked into the image |
+| **Build** | `make autoware-build` takes effect immediately | The image must be rebuilt with `./docker_build.sh eval` |
+| **Laps** | Unlimited | 6 |
+| **Timeout** | Unlimited | 600 seconds |
+| **Termination** | Stop manually with `make down` | Stops automatically when the run is complete |
+| **Output** | Logs only | Scores and driving data are also output |
 
-The typical workflow is to use `make dev` for rapid iteration during development, then run `make eval` before submission for a local evaluation in an environment close to the actual scoring environment.
+During development, the basic flow is to check behavior quickly with `make dev` and, before submitting, run a local evaluation close to the submission environment with `make eval`.
 
-**`make eval` local evaluation flow:**
+Actual races are run with multiple vehicles, so even `make eval` is not exactly the same as the real run. By running in the same evaluation environment as the real one, however, you can detect before submitting the situations in which your code would not work in the real run, for example because it refers to source code outside the submission or depends on libraries that do not exist in the real environment.
+
+**Local evaluation flow with `make eval`:**
 
 ```mermaid
 sequenceDiagram
@@ -136,7 +140,7 @@ sequenceDiagram
     participant Make as make eval
     participant AWSIM as AWSIM
     participant AW as Autoware
-    participant Post as Post-process
+    participant Post as Post-processing
 
     User->>Make: make eval
     Make->>AWSIM: Start container
@@ -145,30 +149,82 @@ sequenceDiagram
     AW->>AWSIM: Send control commands
     Note over AWSIM,AW: 6 laps or timeout
     AWSIM->>AWSIM: Generate result-details.json
-    AWSIM->>Post: Notify run complete
+    AWSIM->>Post: Notify end of run
     Post->>Post: Generate result-summary.json
     Post->>Post: Generate motion_analytics.html
     Post->>Make: Stop and clean up all containers
 ```
 
-### Entering the Docker Container for Debugging
+### Entering a Docker Container for Debugging
 
-While `make dev` is running, you can enter the Autoware container with the following command:
+- To debug, you need an environment in which ROS and Autoware are ready to run, which means entering a Docker container. There are two ways to do this.
+- Method 1) Attach to an existing Autoware container
+    - The `make autoware-attach` command lets you enter a running Autoware container.
+        - After running the command, enter the number of the container you want to enter. Normally, choose the container named `autoware`
+        - This is equivalent to `docker compose exec autoware bash`
+    - Note: an Autoware container must already be running, for example with `make dev`
+- Method 2) Create a new container
+    - The `make autoware-bash` command creates a new container with the runtime environment ready.
+    - This works even when Autoware is not running, so it is useful when you only want the environment itself, for example for machine learning
 
 ```bash
 cd ~/aichallenge-racingkart
-docker compose exec autoware bash
+
+# Method 1) Attach to an existing Autoware container
+make autoware-attach
+# or
+# Method 2) Create a new container
+make autoware-bash
 ```
 
-Inside the container you can inspect ROS topics and run debug commands:
+Inside the container you can check ROS topics and run debugging commands.
 
 ```bash
-# Set domain for vehicle 1
+# Use the domain of vehicle ID 1
 export ROS_DOMAIN_ID=1
 
 # List topics
 ros2 topic list
 
 # Monitor a specific topic
-ros2 topic echo /localization/kinematic_state
+ros2 topic hz /control/command/control_cmd -w 10
 ```
+
+### Running Multiple Vehicles at the Same Time
+
+- This competition uses a race format in which multiple vehicles run at the same time.
+- The following commands run 1 to 4 vehicles at the same time. One AWSIM window shows the vehicles in a split screen, and one Autoware is started per vehicle.
+
+```bash
+# 1 vehicle (default)
+make dev
+
+# 2 vehicles
+make dev2
+
+# 3 vehicles (number of vehicles in SIM qualifying)
+make dev3
+
+# 4 vehicles (number of vehicles in SIM finals)
+make dev4
+```
+
+![autoware-dev3](./images/autoware-dev3.jpg)
+
+### Running the Safety Gate Scenarios { #safety-gate }
+
+- In this competition, you are expected to clear the defined safety gate scenarios.
+- The following commands run scenarios that reproduce each safety gate.
+
+```bash
+# Obstacle stop
+make gate1
+
+# Overtaking
+make gate2
+
+# Lane keeping
+make gate3
+```
+
+![autoware-gate1](./images/autoware-gate1.jpg)


### PR DESCRIPTION
## 概要

英語版の Command Reference（`commands.en.md`）と Development Guide（`development-guide.en.md`）が、既に削除されたスクリプト `run_parallel_submissions.bash` と存在しない make ターゲット `make simulator-reset` を案内していました。日本語版（`commands.ja.md` / `development-guide.ja.md`）は既に現行の実装に追従しており、この PR は英語版を日本語版に合わせて更新し、コードで確認できる誤りを修正します。

### 修正内容
- `run_parallel_submissions.bash` の節を削除（`main`/`dev` に存在しないスクリプト。`make dev2`〜`dev4` に置き換え済み）
- `make simulator-reset` を実在する `make awsim-request-reset` / `make awsim-request-start` に修正
- `make dev` の Laps を「600（実質無制限）」から「Unlimited」に修正（`aichallenge/simulator_scripts/dev.sh` の `--laps unlimited` に一致）
- `make dev2..dev4`、`make e2e`、`make gate1..gate3`、`make simulator-<mode>`、`make autoware-attach`/`make autoware-bash`、`./setup.bash network ...` など、日本語版にのみ存在していたコマンドを英語版にも追加
- 複数台同時起動、Safety Gate シナリオ（`{ #safety-gate }` アンカー付き）の節を追加
- 出力ディレクトリ構成（`latest/` がシンボリックリンクではなく実ディレクトリであること等）を実装に合わせて修正

## Summary

The English Command Reference (`commands.en.md`) and Development Guide (`development-guide.en.md`) documented a script that no longer exists (`run_parallel_submissions.bash`) and a make target that does not exist (`make simulator-reset`). The Japanese pages (`commands.ja.md` / `development-guide.ja.md`) already reflect the current implementation, so this PR brings the English pages in line with them and fixes the code-contradicted statements.

### Changes
- Removed the `run_parallel_submissions.bash` section (the script does not exist on `main` or `dev`; multi-vehicle runs now use `make dev2`..`make dev4`)
- Replaced `make simulator-reset` with the actual targets `make awsim-request-reset` / `make awsim-request-start`
- Fixed the `make dev` Laps row from "600 (effectively unlimited)" to "Unlimited" (matches `--laps unlimited` in `aichallenge/simulator_scripts/dev.sh`)
- Added commands that were only documented on the Japanese page: `make dev2..dev4`, `make e2e`, `make gate1..gate3`, `make simulator-<mode>`, `make autoware-attach`/`make autoware-bash`, `./setup.bash network ...`
- Added the multi-vehicle and Safety Gate scenario sections (with the `{ #safety-gate }` anchor referenced by other pages)
- Corrected the output directory description (`latest/` is a real directory of symlinked files, not a symlinked directory, matching `autostart_orchestrator_node.py`)

## Verification

mkdocs build warning count, before and after (identical, no new warnings):

Before (baseline, 19 total):
```
WARNING -  Doc file 'competition/kart-finals.ja.md' contains a link './sw-class.ja.md#final-abst', but the target 'competition/sw-class.ja.md' is not found among documentation files.
WARNING -  Doc file 'competition/sim-finals-pc.ja.md' contains a link '../specifications/hardware.ja.md', but the target 'specifications/hardware.ja.md' is not found among documentation files.
WARNING -  Doc file 'competition/sim-finals.ja.md' contains a link './ai-class.ja.md#semifinal', but the target 'competition/ai-class.ja.md' is not found among documentation files.
WARNING -  Doc file 'competition/sim-finals.ja.md' contains a link './sw-class.ja.md#overtake-lane', but the target 'competition/sw-class.ja.md' is not found among documentation files.
WARNING -  Doc file 'competition/sim-finals.ja.md' contains a link './sw-class.ja.md#semifinal', but the target 'competition/sw-class.ja.md' is not found among documentation files.
WARNING -  Doc file 'competition/submission.en.md' contains a link '../specifications/submission-contract.en.md', but the target 'specifications/submission-contract.en.md' is not found among documentation files.
WARNING -  Doc file 'competition/submission.ja.md' contains a link '../specifications/submission-contract.ja.md', but the target 'specifications/submission-contract.ja.md' is not found among documentation files.
WARNING -  Doc file 'ml_sample/pilot_net.md' contains a link '../setup/gpu-simulation.ja.md#env-check', but the target 'setup/gpu-simulation.ja.md' is not found among documentation files.
WARNING -  Doc file 'ml_sample/pilot_net.md' contains a link '../setup/introduction.ja.md', but the target 'setup/introduction.ja.md' is not found among documentation files.
WARNING -  Doc file 'ml_sample/soft_actor_critic.md' contains a link '../setup/introduction.ja.md', but the target 'setup/introduction.ja.md' is not found among documentation files.
WARNING -  Doc file 'ml_sample/tiny_lidar_net.md' contains a link '../setup/gpu-simulation.ja.md#env-check', but the target 'setup/gpu-simulation.ja.md' is not found among documentation files.
WARNING -  Doc file 'ml_sample/tiny_lidar_net.md' contains a link '../setup/introduction.ja.md', but the target 'setup/introduction.ja.md' is not found among documentation files.
WARNING -  Doc file 'ml_sample/tiny_lidar_net.md' contains a link '../specifications/simulator.ja.md', but the target 'specifications/simulator.ja.md' is not found among documentation files.
WARNING -  Doc file 'vehicle/operation.ja.md' contains a link '../competition/sw-class.ja.md#final-abst', but the target 'competition/sw-class.ja.md' is not found among documentation files.
WARNING -  Doc file 'vehicle/operation.ja.md' contains a link '../competition/sw-class.ja.md#final-rule', but the target 'competition/sw-class.ja.md' is not found among documentation files.
WARNING -  Doc file 'vehicle/operation.ja.md' contains a link '../competition/sw-class.ja.md#safety-gate', but the target 'competition/sw-class.ja.md' is not found among documentation files.
WARNING -  Doc file 'vehicle/operation.ja.md' contains a link '../development/development-guide.ja.md#safety-gate', but the target 'development/development-guide.ja.md' is not found among documentation files.
WARNING -  mkdocs_static_i18n: mkdocs-material language switcher contextual link is not compatible with theme.features = navigation.instant
WARNING -  mkdocs_static_i18n: mkdocs-material language switcher contextual link is not compatible with theme.features = navigation.instant
```

After (this branch, 19 total, byte-for-byte identical to baseline):
```
WARNING -  Doc file 'competition/kart-finals.ja.md' contains a link './sw-class.ja.md#final-abst', but the target 'competition/sw-class.ja.md' is not found among documentation files.
WARNING -  Doc file 'competition/sim-finals-pc.ja.md' contains a link '../specifications/hardware.ja.md', but the target 'specifications/hardware.ja.md' is not found among documentation files.
WARNING -  Doc file 'competition/sim-finals.ja.md' contains a link './ai-class.ja.md#semifinal', but the target 'competition/ai-class.ja.md' is not found among documentation files.
WARNING -  Doc file 'competition/sim-finals.ja.md' contains a link './sw-class.ja.md#overtake-lane', but the target 'competition/sw-class.ja.md' is not found among documentation files.
WARNING -  Doc file 'competition/sim-finals.ja.md' contains a link './sw-class.ja.md#semifinal', but the target 'competition/sw-class.ja.md' is not found among documentation files.
WARNING -  Doc file 'competition/submission.en.md' contains a link '../specifications/submission-contract.en.md', but the target 'specifications/submission-contract.en.md' is not found among documentation files.
WARNING -  Doc file 'competition/submission.ja.md' contains a link '../specifications/submission-contract.ja.md', but the target 'specifications/submission-contract.ja.md' is not found among documentation files.
WARNING -  Doc file 'ml_sample/pilot_net.md' contains a link '../setup/gpu-simulation.ja.md#env-check', but the target 'setup/gpu-simulation.ja.md' is not found among documentation files.
WARNING -  Doc file 'ml_sample/pilot_net.md' contains a link '../setup/introduction.ja.md', but the target 'setup/introduction.ja.md' is not found among documentation files.
WARNING -  Doc file 'ml_sample/soft_actor_critic.md' contains a link '../setup/introduction.ja.md', but the target 'setup/introduction.ja.md' is not found among documentation files.
WARNING -  Doc file 'ml_sample/tiny_lidar_net.md' contains a link '../setup/gpu-simulation.ja.md#env-check', but the target 'setup/gpu-simulation.ja.md' is not found among documentation files.
WARNING -  Doc file 'ml_sample/tiny_lidar_net.md' contains a link '../setup/introduction.ja.md', but the target 'setup/introduction.ja.md' is not found among documentation files.
WARNING -  Doc file 'ml_sample/tiny_lidar_net.md' contains a link '../specifications/simulator.ja.md', but the target 'specifications/simulator.ja.md' is not found among documentation files.
WARNING -  Doc file 'vehicle/operation.ja.md' contains a link '../competition/sw-class.ja.md#final-abst', but the target 'competition/sw-class.ja.md' is not found among documentation files.
WARNING -  Doc file 'vehicle/operation.ja.md' contains a link '../competition/sw-class.ja.md#final-rule', but the target 'competition/sw-class.ja.md' is not found among documentation files.
WARNING -  Doc file 'vehicle/operation.ja.md' contains a link '../competition/sw-class.ja.md#safety-gate', but the target 'competition/sw-class.ja.md' is not found among documentation files.
WARNING -  Doc file 'vehicle/operation.ja.md' contains a link '../development/development-guide.ja.md#safety-gate', but the target 'development/development-guide.ja.md' is not found among documentation files.
WARNING -  mkdocs_static_i18n: mkdocs-material language switcher contextual link is not compatible with theme.features = navigation.instant
WARNING -  mkdocs_static_i18n: mkdocs-material language switcher contextual link is not compatible with theme.features = navigation.instant
```

No new warnings introduced by this change.

`uvx -q pre-commit run --files docs/development/commands.en.md docs/development/development-guide.en.md`: all hooks passed (check for merge conflicts, detect private key, fix end of files, mixed line ending, trim trailing whitespace, markdownlint, prettier, Markdown Link Check).

---
Team Hayes (Ajayaditya Lokchandra, Nithisha Venkatesh)

本PRはAIコーディング支援を用いて作成し、上記の確認手順で検証しました。 / Prepared with AI coding assistance and verified with the checks above.
