### PR TITLE
docs(competition): fix broken submission-contract link and eval image name

### DIFF
--- a/docs/competition/submission.en.md
+++ b/docs/competition/submission.en.md
@@ -38,7 +38,7 @@ Submit to the online environment using the following steps:
 
     - Run `./create_submit_file.bash` to compress the `aichallenge_submit` directory.
     - The compressed file is saved at `aichallenge-racingkart/submit/aichallenge_submit.tar.gz`.
-    - See the [Submission Contract](../specifications/submission-contract.en.md) for the structure and interfaces your submission must satisfy.
+    - See the [Participant Interface Contract (aichallenge-racingkart repository, in Japanese)](https://github.com/AutomotiveAIChallenge/aichallenge-racingkart/blob/main/docs/interface/participant-interface.md) for the structure and interfaces your submission must satisfy.
 
 2. Verify operation in local evaluation environment
 
@@ -57,16 +57,15 @@ Submit to the online environment using the following steps:
 
     On the upload screen, select the `aichallenge_submit.tar.gz` to upload. You can optionally add a comment. You can also change the rank range of the opponent to challenge — by default you battle the team one rank above you. Widening the range lets you challenge higher-ranked teams, with a larger rating gain if you win. Choose strategically.
 
-    If successful, "Success" will be displayed.
-    If the build fails, the launch fails, or the score is not output, "Failed" will be displayed. In this case, please re-upload as there may be an internal server error. Contact us via Slack if the problem persists.
-
     <img src="./images/siteImage3.png" width="100%">
 
 ## Checking Results
 
-- After the race finishes in the online environment, you can check the latest rankings.
-- Detailed race data including lap times and logs can be checked by clicking the button at the right end of the submission history.
-    - You can check `result-summary.json`, rosbag, and `autoware.log`.
+- After upload, your source code is built and then the simulation is run. You can check the STATUS of this submission under "Your Submissions" at the bottom of the screen. When processing goes normally it changes Queued → Building → Running → Success. The whole process takes about 30 minutes. If the build or the launch fails, "Failed" is displayed; check the logs and your submission (see [If Failed](#if-failed)).
+- When the run in the online environment is finished, you can check the result in the Activity Timeline and the videos. Your rating goes up or down depending on the match result.
+- Clicking the icon on the right of "Your Submissions" at the bottom of the page lets you view and download detailed run data such as lap times and logs.
+    - You can check `result-summary.json`, the rosbag, and `autoware.log`.
+    - "Copy Public Link" at the top right of the screen gives you a link for sharing on social media.
 
     <img src="./images/siteImage4.png" width="100%">
 
@@ -85,11 +84,36 @@ First determine whether it was a **build failure** or a **run failure**.
 
 - Check Docker
 
-    - Use the following command to check inside Docker and verify that everything is correctly installed and built in the required directories.
-
-    - `docker run -it aichallenge-racingkart-eval:latest /bin/bash`
+    - While `make eval` is running, you can enter the container with `make autoware-attach`.
+    - To open the evaluation image directly, run `docker run --rm -it aichallenge-2025-eval bash` (the image name is set in `docker_build.sh`).
 
 - Directories to check:
 
     - `/aichallenge/workspace/*`
     - `/autoware/install/*`
+
+## Online Environment Pages
+
+- "Overview" page (after login only)
+    - Shows your team's rank information and submission history
+- "Live" page
+    - Shows rank information for all teams combined
+- "Student Live" page
+    - Shows rank information for the teams in the student class
+
+- Description of each element
+    - Video on the left
+        - Replay of a match in which the code submitter (CHALLENGER, P1) beat the higher-ranked team (P2)
+    - Video on the right
+        - Replay of a match in which the higher-ranked team (defender, P2) beat the code submitter (P1)
+    - Ranking Table
+        - Shows the ranks of all teams
+    - Activity Timeline
+        - Shows the win/loss history
+        - A sword icon marks a match won by the code submitter (CHALLENGER); a shield icon marks a match won by the higher-ranked team (defender)
+    - Rate Transition
+        - Shows how the rating has changed
+    - Submissions
+        - Shows the code submission history. You can check logs and download ROSBAGs here
+
+<img src="./images/siteImage6.png" width="100%">

--- a/docs/competition/submission.ja.md
+++ b/docs/competition/submission.ja.md
@@ -36,7 +36,7 @@ Queued（受付済み） → Building（ビルド中） → Running（シミュ�
 
     - `./create_submit_file.bash`を実行してaichallenge_submitディレクトリを圧縮します。
     - 圧縮したファイルはaichallenge-racingkart/submit/aichallenge_submit.tar.gzに保存されています。
-    - 提出物が満たすべき構造・インターフェースは[提出物の契約](../specifications/submission-contract.ja.md)を参照してください。
+    - 提出物が満たすべき構造・インターフェースは[参加者インターフェース契約（aichallenge-racingkart リポジトリ）](https://github.com/AutomotiveAIChallenge/aichallenge-racingkart/blob/main/docs/interface/participant-interface.md)を参照してください。
 
 2. ローカル評価環境での動作確認
 
@@ -82,6 +82,7 @@ Queued（受付済み） → Building（ビルド中） → Running（シミュ�
 - dockerの確認
 
     - `make eval`実行中に、`make autoware-attach`でコンテナに入れます
+    - 評価用イメージを直接開く場合は `docker run --rm -it aichallenge-2025-eval bash` を実行します（イメージ名は `docker_build.sh` で設定されています）
 
 - 確認するディレクトリ:
 


### PR DESCRIPTION
## 概要
提出手順の「提出物の契約」へのリンク先（`specifications/submission-contract.*.md`）が存在せず、日英どちらもリンク切れになっていました（`mkdocs build` の WARNING）。同じ内容は aichallenge-racingkart の `docs/interface/participant-interface.md`（main）にあるため、そちらへリンクします。

英語版では加えて、
- デバッグ手順の `docker run -it aichallenge-racingkart-eval:latest` を実在するイメージ名 `aichallenge-2025-eval`（`docker_build.sh`）に修正し、日本語版と同じ `make autoware-attach` の手順を追加
- 2025年の「再アップロード / Slack」の文言を、日本語版の「結果の確認手順」に合わせて更新
- 日本語版にある「オンライン環境のページ概要」を追加

## 確認
`mkdocs build` の WARNING が 2 件減り、新しい WARNING はありません。

## Summary
The "Submission Contract" link in the submission procedure points at `specifications/submission-contract.*.md`, which does not exist, so it is broken in both languages (`mkdocs build` warns). The same content lives in aichallenge-racingkart `docs/interface/participant-interface.md` on `main`; this PR links there.

In the English page it also:
- replaces `docker run -it aichallenge-racingkart-eval:latest` with the real image `aichallenge-2025-eval` (`docker_build.sh`) and adds the `make autoware-attach` route used by the Japanese page
- replaces the 2025 "re-upload / contact via Slack" text with a translation of the Japanese "Checking results" section
- adds the "Online environment pages" section that only the Japanese page had

## Checks
`mkdocs build` drops 2 warnings and adds none.

Before (baseline, 19 total WARNING lines, includes the 2 targeted here):
```
WARNING -  Doc file 'competition/submission.en.md' contains a link '../specifications/submission-contract.en.md', but the target 'specifications/submission-contract.en.md' is not found among documentation files.
WARNING -  Doc file 'competition/submission.ja.md' contains a link '../specifications/submission-contract.ja.md', but the target 'specifications/submission-contract.ja.md' is not found among documentation files.
```

After (17 total WARNING lines): both lines above are gone; no new warnings were introduced.

`pre-commit run` on the two changed files: all hooks passed (check for merge conflicts, detect private key, fix end of files, mixed line ending, trim trailing whitespace, markdownlint, prettier, Markdown Link Check).

---
Team Hayes (Ajayaditya Lokchandra, Nithisha Venkatesh)

本PRはAIコーディング支援を用いて作成し、上記の確認手順で検証しました。 / Prepared with AI coding assistance and verified with the checks above.
