### PR TITLE
chore(github): rename PR template so GitHub picks it up and add a JA/EN checklist

### DIFF
--- a/.github/ PULL_REQUEST_TEMPLATE.md
+++ b/.github/ PULL_REQUEST_TEMPLATE.md
@@ -1,1 +1,0 @@
-# Description

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,13 @@
+## 概要 / Description
+
+<!-- 何を・なぜ変更したか / What changed and why -->
+
+## 関連 / Related
+
+<!-- aichallenge-racingkart の対応 PR・Issue など / Related racingkart PRs or issues -->
+
+## チェックリスト / Checklist
+
+- [ ] `mkdocs build` で新しい WARNING が出ないことを確認した / `mkdocs build` shows no new warnings
+- [ ] 日本語（`.ja.md`）と英語（`.en.md`）の両方を更新した。片方のみの場合は理由を書いた / Updated both `.ja.md` and `.en.md`, or explained why only one
+- [ ] 新しいページを `mkdocs.yaml` の `nav` に追加した / Added any new page to `nav` in `mkdocs.yaml`


### PR DESCRIPTION
## 概要

PR テンプレートのファイル名が `.github/ PULL_REQUEST_TEMPLATE.md`（スラッシュの後に空白）になっており、GitHub に認識されていませんでした（community profile API で `pull_request_template: null`）。正しい名前に変更し、日英の両ページ更新・`mkdocs build` の WARNING・`nav` 追加を確認するチェックリストを入れました。

## 確認

マージ後、新規 PR の本文にテンプレートが入ることを確認してください。

## Summary

The PR template is named `.github/ PULL_REQUEST_TEMPLATE.md` (a space after the slash), so GitHub never uses it (the community profile API reports `pull_request_template: null`). This renames it and adds a bilingual checklist: no new `mkdocs build` warnings, both `.ja.md` and `.en.md` updated, new pages added to `nav`.

## Checks

After merge, a new PR should open with the template pre-filled.

### `mkdocs build` warnings, before / after

- Before (baseline, `/tmp/exec/baseline-warnings.txt`): 19 WARNING lines
- After (`/tmp/exec/warnings-08.txt`): 19 WARNING lines
- Diff: none, no new warnings introduced

---
Team Hayes (Ajayaditya Lokchandra, Nithisha Venkatesh)

本PRはAIコーディング支援を用いて作成し、上記の確認手順で検証しました。 / Prepared with AI coding assistance and verified with the checks above.
