### PR TITLE
docs(setup): fix invalid `git pull origin/main` command

### DIFF
--- a/docs/setup/update-environment.en.md
+++ b/docs/setup/update-environment.en.md
@@ -23,7 +23,7 @@ docker pull ghcr.io/automotiveaichallenge/autoware-universe:humble-latest
 
 ```bash
 cd aichallenge-racingkart # path to aichallenge
-git pull origin/main
+git pull origin main
 ```
 
 ## Updating AWSIM

--- a/docs/setup/update-environment.ja.md
+++ b/docs/setup/update-environment.ja.md
@@ -30,7 +30,7 @@ docker pull ghcr.io/automotiveaichallenge/autoware-universe:humble-latest
 
 ```bash
 cd aichallenge-racingkart # path to aichallenge
-git pull origin/main
+git pull origin main
 ```
 
 ## AWSIMの更新


### PR DESCRIPTION
## 概要
「環境のアップデート」ページの `git pull origin/main` は、`origin/main` がリモート名として解釈されるため、`fatal: 'origin/main' does not appear to be a git repository` で必ず失敗します。`git pull origin main` に修正します（日本語・英語の両方）。

## 確認
racingkart のクローンで確認しました。

```
$ git pull origin/main
fatal: 'origin/main' does not appear to be a git repository
fatal: Could not read from remote repository.

$ git pull origin main --dry-run
From https://github.com/AutomotiveAIChallenge/aichallenge-racingkart
 * branch            main       -> FETCH_HEAD
```

`mkdocs build` の WARNING 件数: 修正前 19 件 → 修正後 19 件（新規警告なし、既存の未対応警告と一致）。

## Summary
`git pull origin/main` on the "Environment updates" page always fails with `fatal: 'origin/main' does not appear to be a git repository`, because git parses `origin/main` as a repository name rather than `<repository> <refspec>`. This changes it to `git pull origin main` in both the Japanese and English pages.

## Checks
Verified in a clone of `aichallenge-racingkart`:

```
$ git pull origin/main
fatal: 'origin/main' does not appear to be a git repository
fatal: Could not read from remote repository.

$ git pull origin main --dry-run
From https://github.com/AutomotiveAIChallenge/aichallenge-racingkart
 * branch            main       -> FETCH_HEAD
```

`mkdocs build` WARNING count: 19 before -> 19 after (no new warnings; matches the pre-existing baseline).

---
Team Hayes (Ajayaditya Lokchandra, Nithisha Venkatesh)

本PRはAIコーディング支援を用いて作成し、上記の確認手順で検証しました。 / Prepared with AI coding assistance and verified with the checks above.
