### PR TITLE
docs(development): explain the make eval 'Waiting for at least 1 matching subscription' hang

### DIFF
--- a/docs/development/development-guide.en.md
+++ b/docs/development/development-guide.en.md
@@ -55,6 +55,19 @@ make down
 make eval
 ```
 
+!!! warning "`make eval` stuck at `Waiting for at least 1 matching subscription(s)...`"
+    After starting the evaluation container, `make eval` runs `make awsim-request-start` (`ros2 topic pub -1 /admin/awsim/start ...` on domain 0). This command keeps waiting until AWSIM subscribes to `/admin/awsim/start`. The evaluation launch (`evaluation.launch.xml`) starts AWSIM and Autoware together, so if the submitted launch fails (for example, a package under `aichallenge_submit` was not built or installed, or a dependency cannot be found), AWSIM shuts down too and the terminal stays on this message.
+
+    Press `Ctrl+C`, run `make down`, then check the following.
+
+    ```bash
+    # Latest run log (launch errors show up here)
+    less "$(ls -td output/2*/d1 | head -n 1)/autoware.log"
+
+    # Check whether your package is installed in the evaluation image (<package> is the package name)
+    docker run --rm aichallenge-2025-eval ls /aichallenge/workspace/install | grep <package>
+    ```
+
 ## Local Evaluation (Multiple Vehicles)
 
 - Use `run_parallel_submissions.bash` to evaluate multiple vehicles at the same time.

--- a/docs/development/development-guide.en.md
+++ b/docs/development/development-guide.en.md
@@ -64,8 +64,8 @@ make eval
     # Latest run log (launch errors show up here)
     less "$(ls -td output/2*/d1 | head -n 1)/autoware.log"
 
-    # Check whether your package is installed in the evaluation image (<package> is the package name)
-    docker run --rm aichallenge-2025-eval ls /aichallenge/workspace/install | grep <package>
+    # Check whether your package is installed in the evaluation image (replace my_package with your package name)
+    docker run --rm aichallenge-2025-eval ls /aichallenge/workspace/install | grep my_package
     ```
 
 ## Local Evaluation (Multiple Vehicles)

--- a/docs/development/development-guide.ja.md
+++ b/docs/development/development-guide.ja.md
@@ -60,6 +60,19 @@ make down
 make eval
 ```
 
+!!! warning "`make eval` が `Waiting for at least 1 matching subscription(s)...` のまま進まない場合"
+    `make eval` は評価コンテナを起動したあと、`make awsim-request-start`（ドメイン0で `ros2 topic pub -1 /admin/awsim/start ...`）を実行します。このコマンドは AWSIM が `/admin/awsim/start` を購読するまで待ち続けます。評価用の launch（`evaluation.launch.xml`）は AWSIM と Autoware を同じ launch で起動するため、提出パッケージの launch が失敗する（例: `aichallenge_submit` 内のパッケージがビルド・インストールされていない、依存パッケージが見つからない）と AWSIM ごと終了し、この表示のまま止まります。
+
+    `Ctrl+C` で抜けて `make down` した後、以下を確認してください。
+
+    ```bash
+    # 最新の実行ログ（launch のエラーはここに出ます）
+    less "$(ls -td output/2*/d1 | head -n 1)/autoware.log"
+
+    # 評価用イメージに自分のパッケージがインストールされているか確認（<package> はパッケージ名）
+    docker run --rm aichallenge-2025-eval ls /aichallenge/workspace/install | grep <package>
+    ```
+
 ## 結果の出力
 
 ### ワークスペースのビルド生成物

--- a/docs/development/development-guide.ja.md
+++ b/docs/development/development-guide.ja.md
@@ -69,8 +69,8 @@ make eval
     # 最新の実行ログ（launch のエラーはここに出ます）
     less "$(ls -td output/2*/d1 | head -n 1)/autoware.log"
 
-    # 評価用イメージに自分のパッケージがインストールされているか確認（<package> はパッケージ名）
-    docker run --rm aichallenge-2025-eval ls /aichallenge/workspace/install | grep <package>
+    # 評価用イメージに自分のパッケージがインストールされているか確認（my_package は自分のパッケージ名に置き換える）
+    docker run --rm aichallenge-2025-eval ls /aichallenge/workspace/install | grep my_package
     ```
 
 ## 結果の出力


### PR DESCRIPTION
## 概要

提出パッケージの launch が失敗すると、`make eval` は `Waiting for at least 1 matching subscription(s)...` のまま止まり、原因が画面に出ません。これは `make awsim-request-start`（`ros2 topic pub -1 /admin/awsim/start ...`）が AWSIM の購読を待ち続けるためで、評価用の launch（`evaluation.launch.xml`）は AWSIM と Autoware を同じ launch で起動するため、提出パッケージの launch 失敗（未ビルド・未インストールのパッケージ、依存パッケージの欠落など）で AWSIM ごと終了し、この表示のまま止まります。

`docs/development/development-guide.ja.md` の「ローカル評価」の `make eval` コマンドの直後に、この仕組みと診断手順（`autoware.log` の確認、評価イメージの `install/` の確認）を説明する警告ボックスを追加しました。EN 版の同ページ（`development-guide.en.md`）にも同じ内容の警告ボックスを追加しています（DOCS-05 が未マージのため、既存の `make eval` コードブロックの直後に追記）。

## Summary

When the submitted launch fails, `make eval` stops at `Waiting for at least 1 matching subscription(s)...` without showing the cause. This happens because `make awsim-request-start` (`ros2 topic pub -1 /admin/awsim/start ...`) waits for AWSIM to subscribe, and the evaluation launch (`evaluation.launch.xml`) starts AWSIM and Autoware together, so a failure in the submitted launch (an unbuilt/uninstalled package, a missing dependency, etc.) takes AWSIM down too, leaving the terminal stuck on that message.

This adds a warning box right after the `make eval` command in "Local Evaluation" in `docs/development/development-guide.ja.md`, explaining the mechanism and how to diagnose it (checking `autoware.log`, checking the `install/` tree of the evaluation image). The same box was added to the EN version of the page (`development-guide.en.md`), since DOCS-05 (which would otherwise carry this note) is not yet merged.

## Checks

- `mkdocs build` WARNING count: before 19, after 19 (no new warnings; `diff` against the pre-change build was empty).
- `uvx pre-commit run` on both changed files: all hooks passed (markdownlint, prettier, Markdown Link Check, trailing whitespace, end-of-file, etc.).
- Reproduced the underlying failure by including a non-existent package in the submitted launch file and running `make eval`: it hangs at the message above, and `autoware.log` shows `Caught exception in launch`, confirming the documented mechanism.

---
Team Hayes (Ajayaditya Lokchandra, Nithisha Venkatesh)

本PRはAIコーディング支援を用いて作成し、上記の確認手順で検証しました。 / Prepared with AI coding assistance and verified with the checks above.
