### PR TITLE
docs(development): correct the output/latest tree in the development guide

### DIFF
--- a/docs/development/development-guide.ja.md
+++ b/docs/development/development-guide.ja.md
@@ -75,23 +75,24 @@ make eval
 ```text
 output/
 ├── <実行日時>/
+│   ├── awsim.log                                 # AWSIM の実行ログ（make dev の場合）
 │   └── d1/
 │       ├── autoware.log                          # Autoware の実行ログ
-│       ├── awsim.log                             # AWSIM の実行ログ（make devのみ）
 │       ├── ros/log/                              # 各ノードの個別ログ
-│       ├── capture/                              # キャプチャ動画
+│       ├── capture/                              # キャプチャ動画（cap-*.mp4）
 │       ├── rosbag2_autoware/                     # ROSBagファイル
 │       ├── d1-result-details.json                # 詳細な走行データ (make evalのみ)
 │       ├── result-summary.json                   # ラップタイムの結果サマリー (make evalのみ)
 │       └── motion_analytics-<timestamp>.html     # 速度・加速度の可視化 (make evalのみ)
-├── latest/                                       # 最新の評価結果へのシンボリックリンク (make evalのみ)
-│   └── d1/                                       # output/<実行日時>/d1/ へのシンボリックリンク
+├── latest/                                       # 実ディレクトリ。中身が最新の成果物へのシンボリックリンク (make evalのみ)
+│   ├── docker_build.log                          # 最新の docker_build.sh のビルドログ
+│   └── d1/
 │       ├── autoware.log                          # Autoware の実行ログ
-│       ├── capture/                              # キャプチャ動画
-│       ├── rosbag2_autoware/                     # ROSBag記録（MCAP形式）
-│       ├── d1-result-details.json                # 詳細な走行データ
+│       ├── capture.mp4                           # キャプチャ動画
+│       ├── rosbag2_autoware.mcap                 # ROSBag記録（MCAP形式）
+│       ├── result-details.json                   # 詳細な走行データ（d1-result-details.json へのリンク）
 │       ├── result-summary.json                   # ラップタイムの結果サマリー
-│       └── motion_analytics-<timestamp>.html     # 速度・加速度のインタラクティブ可視化
+│       └── motion_analytics.html                 # 速度・加速度のインタラクティブ可視化
 └── docker/
     └── <実行日時>-docker_build-<pid>.log          # docker_build.sh のビルドログ
 ```


### PR DESCRIPTION
## 概要（日本語）

開発ガイドの「実行結果の出力」ツリーで、`output/latest/d1/` 配下に実際には作られないファイル（`capture/`、`rosbag2_autoware/`、`d1-result-details.json`、`motion_analytics-<timestamp>.html`）が記載されていました。`autostart_orchestrator_node.py` が実際に作成するリンク名（`capture.mp4`、`rosbag2_autoware.mcap`、`result-details.json`、`motion_analytics.html`）に合わせて修正し、`latest/` が実ディレクトリであること（`docker_build.log` を含む）、`awsim.log` の位置（`make dev` では `<実行日時>/awsim.log` に置かれ、`d1/` の中ではない）も修正しました。

このツリーは日本語版のみに存在する記述です。英語版 `development-guide.en.md` の同等箇所は別PR（DOCS-05相当）で修正されます。

## Summary (English)

The "Execution output" tree in the Development Guide listed files under `output/latest/d1/` that are never actually created (`capture/`, `rosbag2_autoware/`, `d1-result-details.json`, `motion_analytics-<timestamp>.html`). This aligns the tree with the link names `autostart_orchestrator_node.py` actually creates (`capture.mp4`, `rosbag2_autoware.mcap`, `result-details.json`, `motion_analytics.html`), states that `latest/` is a real directory (including `docker_build.log`), and fixes where `awsim.log` lives (`<timestamp>/awsim.log` for `make dev`, not inside `d1/`).

This tree only exists on the Japanese page. The equivalent section on `development-guide.en.md` is fixed in a companion PR (DOCS-05).

## 確認結果 / Verification

- `mkdocs build` warning count: before 19, after 19 (no new warnings introduced).
- Diff of sorted WARNING lines (`baseline-warnings.txt` vs `warnings-11.txt`): empty, no new warnings and none removed.
- `uvx pre-commit run --files docs/development/development-guide.ja.md`: all hooks passed (markdownlint, prettier, markdown-link-check, etc.), no files were reformatted.

---
Team Hayes (Ajayaditya Lokchandra, Nithisha Venkatesh)

本PRはAIコーディング支援を用いて作成し、上記の確認手順で検証しました。 / Prepared with AI coding assistance and verified with the checks above.
