### PR TITLE
docs(setup): sync English setup pages with Japanese (requirements, GPU/headless, troubleshooting)

### DIFF
--- a/docs/setup/gpu-simulation.en.md
+++ b/docs/setup/gpu-simulation.en.md
@@ -1,31 +1,25 @@
-# GPU Settings
+# GPU Settings and Runtime Settings
 
-First, follow [Setting Up the Environment](./introduction.en.md) to complete the setup.
-If you encounter issues with AWSIM rendering or GPU configuration, refer to this page.
-
-## GPU Environment Support
-
-| Environment | Support | AWSIM Rendering | Sensors |
-| ----------- | ------- | --------------- | ------- |
-| **NVIDIA GPU present** | Supported | Yes | Yes |
-| **Intel integrated GPU only (no NVIDIA)** | Supported | Yes | No |
-| **No GPU** | Not supported | No | No |
-
-- **NVIDIA GPU present**: AWSIM and Autoware can run with GPU acceleration.
-- **Intel integrated GPU only**: AWSIM will launch, but sensor simulation does not work. This can be used to verify that AWSIM at least starts.
-- **No GPU**: Not supported. AWSIM cannot be launched. If needed, try the headless mode described below.
+First, complete the setup by following [Setting Up the Environment](./introduction.en.md). If you run into problems with AWSIM rendering or GPU settings, refer to this page.
+Camera/LiDAR are disabled by default. If you are taking part in the AI division, configure them by following [Switching Camera/LiDAR Settings](#camera-lidar).
 
 ## Checking .env { #env-check }
 
-Check `~/aichallenge-racingkart/.env` and confirm it has the following settings. This is configured automatically by `setup.bash`. When `setup.bash` detects `/dev/nvidia0`, it automatically adds `docker-compose.gpu.yml` to `COMPOSE_FILE` in `.env`. If you are using an NVIDIA GPU but the settings differ, complete the NVIDIA GPU setup described below and then update `.env`.
+Check `~/aichallenge-racingkart/.env` and confirm that it has the settings below. This is configured automatically by `setup.bash`. When `setup.bash` detects `/dev/nvidia0`, `COMPOSE_FILE` in `.env` is set automatically.
+
+If you are using an NVIDIA GPU but the setting is different, complete the NVIDIA GPU setup described below and then update `.env`.
 
 ```bash
-# When using NVIDIA GPU (enable docker-compose.gpu.yml)
-COMPOSE_FILE=docker-compose.yml:docker-compose.gpu.yml
+# ご自身の環境に合う行を有効にして、他の行はコメントアウトしてください
 
-# Intel integrated GPU only (leave the above line commented out)
-# COMPOSE_FILE=docker-compose.yml:docker-compose.gpu.yml
+# Intel 内蔵 GPU のみの場合・GPU未搭載の場合
+COMPOSE_FILE=docker-compose.yml
+
+# NVIDIA GPU 利用時
+# COMPOSE_FILE=docker-compose.yml:docker-compose.gpu.yml:docker-compose.sound.yml
 ```
+
+(Translation of the comments above: "Enable the line that matches your environment and comment out the others" / "Intel integrated GPU only, or no GPU" / "When using an NVIDIA GPU".)
 
 ## Installing GPU Drivers and Toolkits
 
@@ -35,8 +29,8 @@ COMPOSE_FILE=docker-compose.yml:docker-compose.gpu.yml
 
 **NVIDIA GPU only:**
 
-- Install NVIDIA driver (reboot recommended after installation)
-- Install NVIDIA Container Toolkit
+- Install the NVIDIA driver (a reboot is generally recommended)
+- Install the NVIDIA Container Toolkit
 
 ??? note "Vulkan installation steps"
     Run the following commands.
@@ -48,60 +42,61 @@ COMPOSE_FILE=docker-compose.yml:docker-compose.gpu.yml
 
 ??? note "NVIDIA driver installation steps"
     ```bash
-    # Add repository
+    # リポジトリの追加
     sudo add-apt-repository ppa:graphics-drivers/ppa
 
-    # Update package list
+    # パッケージリストの更新
     sudo apt update
 
-    # Install
+    # インストール
     sudo ubuntu-drivers install
 
-    # Update package list
+    # パッケージリストの更新
     sudo apt update
 
-    # Verify installation with the command below.
-    # The change is almost never reflected immediately, so a reboot (see below) is recommended.
+    # 下記のコマンドでインストールできていることを確認
+    # 99%反映されないので、下記のrebootコマンドで再起動することを推奨します。
     nvidia-smi
     ```
 
-    The following command will reboot your PC — be careful if you do not want to power off at this point!
+    (Comments above, in order: add the repository / update the package list / install / update the package list / check the installation with the command below, it is almost never reflected yet, so rebooting with the reboot command below is recommended.)
+
+    The following command reboots your PC, so be careful if you do not want to power off at this point!
     ```bash
-    # Reboot
+    # 再起動
     reboot
     ```
 
     ```bash
-    # After reboot, verify the installation
+    # 再起動の後、インストールできていることを確認
     nvidia-smi
     ```
 
     ![nvidia-smi](./images/nvidia-smi.png)
 
 ??? note "NVIDIA Container Toolkit installation steps"
-    Follow the official NVIDIA Container Toolkit instructions
-    (`https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/install-guide.html`)
-    to perform the installation.
+    Install by following the official NVIDIA Container Toolkit instructions
+    (`https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/install-guide.html`).
 
     ```bash
-    # Preparation
+    # インストールの下準備
     distribution=$(. /etc/os-release;echo $ID$VERSION_ID) \
           && curl -fsSL https://nvidia.github.io/libnvidia-container/gpgkey | sudo gpg --dearmor -o /usr/share/keyrings/nvidia-container-toolkit-keyring.gpg \
           && curl -s -L https://nvidia.github.io/libnvidia-container/$distribution/libnvidia-container.list | \
                 sed 's#deb https://#deb [signed-by=/usr/share/keyrings/nvidia-container-toolkit-keyring.gpg] https://#g' | \
                 sudo tee /etc/apt/sources.list.d/nvidia-container-toolkit.list
 
-    # Install
+    # インストール
     sudo apt-get update
     sudo apt-get install -y nvidia-container-toolkit
     sudo nvidia-ctk runtime configure --runtime=docker
     sudo systemctl restart docker
 
-    # Test the installation
+    # インストールできているかをテスト
     sudo docker run --rm --runtime=nvidia --gpus all nvidia/cuda:11.6.2-base-ubuntu20.04 nvidia-smi
 
-    # If the last command outputs something like the following, the installation was successful.
-    # (The example below is quoted from the NVIDIA website)
+    # 最後のコマンドで以下のように出力されれば成功です。
+    # （下記はNVIDIAウェブサイトからの引用です）
     #
     # +-----------------------------------------------------------------------------+
     # | NVIDIA-SMI 450.51.06    Driver Version: 450.51.06    CUDA Version: 11.0     |
@@ -123,8 +118,10 @@ COMPOSE_FILE=docker-compose.yml:docker-compose.gpu.yml
     # +-----------------------------------------------------------------------------+
     ```
 
+    (Comments above, in order: preparation / install / test the installation / if the last command prints something like the following, it succeeded, quoted from the NVIDIA website.)
+
 !!! warning
-    You do not need to follow steps that are already completed. The NVIDIA setup steps here are provided as a reference only — please refer to the official NVIDIA documentation for details.
+    You do not need to repeat steps you have already completed. The NVIDIA setup steps here are for reference only; see NVIDIA's official instructions for details.
 
 ## Verifying AWSIM Launch
 
@@ -135,30 +132,67 @@ cd aichallenge-racingkart
 make simulator
 ```
 
-If the simulator appears as shown below, the launch was successful.
+If the simulator appears as shown below, it succeeded.
 ![AWSIM-Autoware](./images/awsim.png)
 
-Try launching Autoware as well.
+Now try launching Autoware as well.
 
 ```bash
 cd aichallenge-racingkart
-make autoware-build # Only needed if you have never built before
+make autoware-build # 一度もbuildしてない方のみでOK
 make autoware-simulator
 ```
 
-If the following screen appears, the launch was successful.
+(`# 一度もbuildしてない方のみでOK` = "only needed if you have never built".)
+
+If a screen like the following appears, it succeeded.
 
 ![AWSIM-Autoware](./images/awsim-and-autoware.png)
 
-Once you have confirmed, run the following command.
+When you have finished checking, run the following command.
 
 ```bash
 make down
 ```
 
-## Headless Execution Without GPU (Not Officially Supported)
+## Headless Execution on PCs Without a GPU
 
-This is not officially supported, but AWSIM can be run in headless mode on a GPU-less environment with the following steps. The AWSIM window will not be displayed, but you can monitor the status in RViz.
+If your PC has no GPU, you must run AWSIM in headless mode with the steps below. The AWSIM window is not displayed in this case, but you can monitor the situation in RViz.
 
-1. In `aichallenge/run_simulator.bash`, add `--headless` to the `AWSIM.x86_64` launch options.
-2. Remove `- /dev/dri:/dev/dri` from `docker-compose.yml`.
+1. In `aichallenge-racingkart/aichallenge/simulator_scripts/dev.sh`, add `-headless` to the launch options of `AWSIM.x86_64`.
+    - Note: if you add it at the end, do not forget to put a `\` at the end of the line of the preceding existing option.
+2. Remove the line `- /dev/dri:/dev/dri` from `aichallenge-racingkart/docker-compose.yml`.
+
+## Switching Camera/LiDAR Settings { #camera-lidar }
+
+- By default, Camera and LiDAR are disabled. Participants in the End to End AI division must enable Camera and LiDAR.
+  - AI division participants are assumed to have a PC with an NVIDIA GPU, so we recommend setting them to `gpu`.
+- Edit the launch options of `AWSIM.x86_64` in `aichallenge-racingkart/aichallenge/simulator_scripts/dev.sh`.
+    - For local evaluation runs, edit `eval.sh` in the same way.
+    - For safety gate scenario runs, edit `gate.sh` in the same way.
+
+```bash
+# Cameraの設定
+## 無効 (デフォルト)
+--camera off
+
+## 有効 (CPU処理)
+--camera cpu
+
+## 有効 (GPU処理)
+--camera gpu
+```
+
+```bash
+# LiDARの設定
+## 無効 (デフォルト)
+--lidar off
+
+## 有効 (CPU処理)
+--lidar cpu
+
+## 有効 (GPU処理)
+--lidar gpu
+```
+
+(Comments above: Camera / LiDAR setting, disabled (default), enabled (CPU processing), enabled (GPU processing).)

--- a/docs/setup/introduction.en.md
+++ b/docs/setup/introduction.en.md
@@ -1,10 +1,12 @@
 # Setting Up the Environment
 
-This chapter explains how to set up the development and execution environment for the Autonomous Driving AI Challenge 2026 (Racing Kart). It covers verifying the recommended environment, preparing the workspace, and launching Docker and AWSIM.
+This chapter explains how to set up the development and execution environment for the Autonomous Driving AI Challenge 2026 (Racing Kart). A single setup script takes you through package installation, building the virtual environment, preparing the workspace, and launching Docker and AWSIM.
 
 ??? info "Changes for 2025 participants"
       - `rocker` is now limited to GUI forwarding; process management uses docker compose.
       - Individual setup steps have been consolidated into a single batch installation procedure.
+
+<iframe width="960" height="540" src="https://www.youtube.com/embed/K_ToeWGitbk?si=Chop0CTjs0rx-itt" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
 
 ## Environment Setup
 
@@ -28,8 +30,6 @@ curl -fsSL "https://raw.githubusercontent.com/AutomotiveAIChallenge/aichallenge-
     cd ~/aichallenge-racingkart
     ./setup.bash bootstrap
     ```
-
-What this single command does (regarding the virtual environment)
 
 The following describes what `setup.bash` performs interactively, step by step. Open only the steps you need to review.
 
@@ -240,9 +240,11 @@ cd ~/aichallenge-racingkart
 make down
 ```
 
-This completes the environment setup and operation check.
+## If Something Goes Wrong
 
-- If AWSIM does not launch or has rendering issues, check your GPU settings.
-    - [GPU Settings](./gpu-simulation.en.md)
-- If you are ready to start developing, see the development guide.
-    - [Development Guide](../development/development-guide.en.md)
+- First log out and log back in, then try the setup again. Docker-related permission settings and various parameter settings may not have taken effect yet.
+- Scroll back up in the terminal and check whether any errors or warnings were printed.
+- You can run an environment check with the `./setup.bash doctor` command. If warnings or info messages are shown, try the remedy given for each.
+- If NVIDIA-related errors appeared, AWSIM does not start, or there are rendering problems, see [GPU Settings and Runtime Settings](./gpu-simulation.en.md).
+    - If you are taking part in the AI division you must enable Camera/LiDAR. See the steps on the same page.
+- Very occasionally AWSIM fails to start. If only the AWSIM window stays black, stop all containers with the `make down_all` command and try again.

--- a/docs/setup/requirements.en.md
+++ b/docs/setup/requirements.en.md
@@ -1,40 +1,66 @@
 # Recommended Environment
 
-For the PC used in this competition, we recommend the following specifications. While it is possible to run with lower specifications, it may result in unstable execution speeds on the ROS 2 side, causing significant variations in behavior during simulations.
+We recommend the following specifications for the PC you use in this competition.
+Items marked "recommended" are not strictly required for the software to run. However, if you run on a PC with lower specifications than recommended, execution speed on the ROS 2 side may become unstable, and behavior may change significantly from one simulation run to the next.
 
 !!! warning
 
-    Running AWSIM in headless mode is required for environments without a GPU, but this is not officially supported.
+    If you only have a Windows environment, please install Ubuntu 22.04. It is possible to install Ubuntu on the same disk as Windows, but if you are not familiar with the process you may damage your Windows installation, so we strongly recommend buying a new external or internal SSD and installing Ubuntu there.
 
-    If you only have a Windows environment, please install Ubuntu 22.04. While it is possible to install Ubuntu on the same disk as your Windows environment, if you are not familiar with the process, you may accidentally damage your Windows environment. Therefore, we strongly recommend purchasing a new external or internal SSD and installing Ubuntu there.
+    Ubuntu 24.04 may work, but it is not officially supported.
+
+    WSL can also run the stack in headless mode (without the simulator window), but it is not officially supported.
 
 !!! info
 
     For guidance on installing Ubuntu, [this article](https://qiita.com/kiwsdiv/items/1fa6cf451225492b33d8) may be helpful.
 
-## For PCs with an NVIDIA GPU
+## GPU Environment Support
+
+| Environment | AWSIM Rendering | Camera/LiDAR |
+| ---- |  --------- | -------- |
+| **NVIDIA GPU** |  Yes | Yes |
+| **Intel integrated GPU only** |  Yes | No |
+| **No GPU** |  No | No |
+
+- **NVIDIA GPU**: AWSIM and Autoware can run with GPU acceleration. This environment is required for the End to End AI division.
+- **Intel integrated GPU only**: AWSIM launches, but the Camera/LiDAR sensors cannot be used. This environment is sufficient for the Sim to Real SW division.
+- **No GPU**: The stack can run in headless mode, in which the AWSIM window is not displayed. You can do a minimal operation check in RViz.
+
+## PC Specifications (Guideline)
+
+The following are the PC specifications required for development and execution. For the specifications of the PCs actually used in the competition, see [Specifications / Hardware](../specifications/hardware.en.md).
 
 - OS: Ubuntu 22.04
-- CPU: Intel Core i7 (8 cores) or higher (recommended)
-- GPU: NVIDIA GeForce with 8 GB VRAM or more (recommended)
-- Memory: 16 GB or more
-- SSD: 60 GB or more
-
-## For PCs with Intel Integrated GPU Only
-
-- OS: Ubuntu 22.04
-- CPU: 13th Gen Intel Core i7 (8 cores) or higher (recommended)
-- GPU: Integrated GPU of the above CPU
-- Memory: 16 GB or more
-- SSD: 60 GB or more
-- Limitation: Sensor simulation is not available.
-
-## For PCs without a GPU
-
-- OS: Ubuntu 22.04
-- CPU: Intel Core i5 (4 cores) or higher (recommended)
+- CPU:
+    - 11th Gen Intel Core i5 (8 cores) or higher (minimum)
+    - 13th Gen Intel Core i7 (8 cores) or higher (recommended)
+- GPU:
+    - With an NVIDIA GPU
+        - GTX 1650 or higher (minimum)
+        - RTX 3060 or higher (recommended)
+    - With an Intel integrated GPU only
+        - Iris Xe Graphics or higher
+    - Without a GPU
+        - None
 - Memory:
-    - Minimum: 8 GB
-    - Recommended: 16 GB or more
+    - 4 GB or more (minimum)
+    - 8 GB or more (recommended)
 - SSD: 60 GB or more
-- Limitation: Sensor simulation is not available. AWSIM runs in headless mode without visualization. This is not an officially supported environment.
+
+If you train machine learning models for the End to End AI division, we additionally recommend an NVIDIA GPU with the following performance:
+
+- 4 GB VRAM or more (e.g. GTX 1650, RTX 3050) (minimum)
+- 8 GB VRAM or more (e.g. RTX 3060, RTX 4060) (recommended)
+
+## Checking Your Environment
+
+- The specifications above are guidelines. To check whether your own environment can run the stack, actually try it by following [Setting Up the Environment](./introduction.en.md).
+- While Autoware is running, check that each process runs at the expected rate.
+    - The FPS shown at the top right of the AWSIM window is 30 FPS or higher (60 FPS ideally)
+    - The frequency of the `/control/command/control_cmd` topic, shown by the command below, is about 40 Hz (when the control algorithm is MPC, the default setting; about 100 Hz when the control algorithm is SimplePurePursuit)
+
+        ```bash
+        make autoware-bash
+        ros2 topic hz /control/command/control_cmd -w 10
+        ```


### PR DESCRIPTION
## 概要（日本語）

英語版の環境構築ページ（`setup/requirements.en.md`・`setup/gpu-simulation.en.md`・`setup/introduction.en.md`）を最新の日本語版に同期しました。

- 推奨環境: GPU 対応表、End to End AI 部門では NVIDIA GPU が必要である旨、メモリ要件（最低 4GB / 推奨 8GB）、環境の確認方法を追加
- GPU 設定: NVIDIA 利用時の `COMPOSE_FILE` を `.env.example` / `setup.bash` と同じ `docker-compose.yml:docker-compose.gpu.yml:docker-compose.sound.yml` に修正（従来の英語版は sound overlay が抜けていました）
- ヘッドレス実行: 英語版では `run_simulator.bash` に `--headless` を追加する手順になっていましたが、実際には `simulator_scripts/dev.sh` に `-headless`（シングルダッシュ）を追加する必要があるため修正
- 英語版に無かった「Camera/LiDAR設定の切り替え」（`#camera-lidar`）と「うまくいかない場合」を追加

コードブロックは日本語版とバイト一致です（コメントの英訳はブロック外に併記）。`mkdocs build` の警告は増えていません。

**注意:** 現在オープン中の PR #76 も `setup/introduction.{ja,en}.md` を編集しています（`git clone` コマンドに `-b main` を追加する変更、89行目付近）。本 PR は同ファイルの別の箇所（冒頭の説明文・トラブルシューティング節）を編集しており行の重複はありませんが、マージ順序によっては先にマージされた側でもう一方のリベースが必要になる可能性があります。マージ前に調整してください。

## Summary (English)

Syncs the English setup pages with the current Japanese pages.

- Requirements: add the GPU capability table, state that the End to End AI division requires an NVIDIA GPU, fix memory requirements (4 GB min / 8 GB recommended), add "Checking your environment".
- GPU settings: the NVIDIA `COMPOSE_FILE` line now matches `.env.example` and what `setup.bash` writes (`docker-compose.yml:docker-compose.gpu.yml:docker-compose.sound.yml`); the previous EN page was missing the sound overlay.
- Headless: EN said to add `--headless` to `run_simulator.bash`; that script only dispatches to `simulator_scripts/<mode>.sh`, and the Unity flag is `-headless` (single dash). Now matches JA.
- Add the missing "Switching Camera/LiDAR settings" section (`#camera-lidar`) and the troubleshooting section.

Code blocks are byte-identical to JA (comment glosses placed after each block). No new `mkdocs build` warnings.

**Note on overlap with PR #76:** the open PR #76 also touches `setup/introduction.{ja,en}.md` (adds `-b main` to the `git clone` command, around line 89). This PR edits different parts of the same files (the intro paragraph and the troubleshooting section at the end), so there is no line-level conflict, but whichever of the two PRs merges second may need a rebase against the other. Please coordinate/rebase before merging both.

## Test plan

- [x] `mkdocs build` warnings: 19 before, 19 after (`diff` of sorted warning lists is empty; no new warnings)
- [x] Rendered `en/setup/gpu-simulation.html` contains the new `#camera-lidar` anchor
- [x] Rendered `en/setup/requirements.html` contains "4 GB or more"
- [x] `pre-commit run` on the three changed files: all hooks passed (markdownlint, prettier, markdown-link-check, etc.)

---
Team Hayes (Ajayaditya Lokchandra, Nithisha Venkatesh)

本PRはAIコーディング支援を用いて作成し、上記の確認手順で検証しました。 / Prepared with AI coding assistance and verified with the checks above.
