### PR TITLE
docs(getting-started): resync English getting-started, hardware and index pages

### DIFF
--- a/docs/getting-started.en.md
+++ b/docs/getting-started.en.md
@@ -1,48 +1,109 @@
 # Getting Started
 
-This page outlines the steps to participate in the AI Challenge.
+This page describes the overall flow of the AI Challenge.
 
-You can participate in this competition with a single PC running Ubuntu 22.04.
+You can take part in this competition with a single PC running Ubuntu 22.04.
 
-First, use the online scoring environment, then proceed with [environment setup](./setup/requirements.en.md) and [development](./development/development-guide.en.md).
+First use the online scoring environment, then move on to environment setup and development.
 
-## Register for the Autonomous Driving AI Challenge 2025
+??? note  "1. Register for the Autonomous Driving AI Challenge"
 
-Registration for the 2025 competitions have already been closed.
+    Register for this year's competition via the [:material-launch: registration form](https://questant.jp/q/QUHU0GNO){ .md-button .md-button--primary target="_blank" }
 
-## Accessing and Submitting to the [Online Scoring Environment](https://aichallenge-board.jsae.or.jp/live)
+??? note  "2. Access the online scoring environment"
 
-In this competition, you will upload submission files (compressed source code files) to the online environment, where they will be automatically scored and ranked.
+    In this competition, you upload a submission file (a compressed archive of your source code) to the online environment, where it is scored automatically and your ranking is determined.
 
-Let's try using the online scoring environment with these four steps!
-!!! info
+    First, try the online scoring environment in the following two steps!
+    !!! info
 
-    Accessing the online scoring environment and submitting a file should take about 5 minutes.
+        It takes about 5 minutes from accessing the online scoring environment to submitting.
 
-1. After registering for the Autonomous Driving AI Challenge, login information will be sent to your registered email address.
+    1. After you register for the Autonomous Driving AI Challenge, login information is sent to your registered email address.
 
-2. Access the [online scoring environment](https://aichallenge-board.jsae.or.jp/live) and log in using the credentials provided in the email.
+    2. Access the [:material-launch: online scoring environment](https://aichallenge-board.jsae.or.jp){ .md-button .md-button--primary target="_blank" } and log in with the credentials given in the email.
 
-3. Once you have access, try submitting a source code file. Download the sample code compressed file from the red button below.
+??? note  "3. Submit the sample code"
 
-4. Upload the file directly through the "UPLOAD" button in the online scoring environment to submit it.
+    1. Once you have access, try submitting source code once.
+    Download the compressed sample code from the red button below.
 
-<!-- [Download the sample code compressed file](https://drive.google.com/file/d/19LU70cgeg48R6stEXjvwDp1pTT25OjeN){ .md-button .md-button--primary .banner-button } -->
+    2. Upload it as-is with the "Submit Code" button in the online scoring environment to submit it.
 
-![submit](./competition/images/submit.png)
+    [:material-launch: Download the compressed sample code](https://github.com/AutomotiveAIChallenge/aichallenge-racingkart/releases){ .md-button .md-button--primary  target="_blank" }
 
-## [Setting Up the AI Challenge Environment](./setup/requirements.en.md)
+    ![submit](./competition/images/siteImage2.png)
 
-Please follow the link above to set up the environment.
-!!! info
+    ![submit](./competition/images/submit.png)
 
-    You can participate in this competition with a single PC running Ubuntu 22.04.
+??? note  "4. Set your team icon"
+    Please set an icon for your team. Using generative AI such as ChatGPT is an effective way to create one.
+    The icon you create is also shown in the list of participants' skills based on the SDV skill standard.
 
-## [How to Proceed with Development in the AI Challenge](./development/development-guide.en.md)
+    [:material-launch: Participants' skills](https://aichallenge-board.jsae.or.jp/public/jobs){ .md-button .md-button--primary}
 
-Let's start developing by following the link above!
+??? note  "5. Set up the AI Challenge environment"
 
-## [Submitting Your Source Code](./competition/submission.en.md)
+    Once you have submitted the sample code, set up your development environment next.
 
-Submit your completed code via the [online scoring environment](https://aichallenge-board.jsae.or.jp/live).
-Set up your submission using the link above.
+    [:material-arrow-right-circle: Setting up the AI Challenge environment](./setup/requirements.en.md){ .md-button .md-button--primary}
+    !!! note
+
+        You can take part in this competition with a single PC running Ubuntu 22.04.
+
+??? note  "6. How to develop in the AI Challenge"
+
+    When the environment setup is complete, try improving the autonomous driving software.
+
+    [:material-arrow-right-circle: How to develop in the AI Challenge](./development/workspace-usage.en.md){ .md-button .md-button--primary }
+
+??? note  "7. Submit the code you developed"
+
+    Submit your finished code from the [online scoring environment](https://aichallenge-board.jsae.or.jp/live).
+    Try submitting again via the link below.
+
+    [:material-launch: Submitting source code](./competition/submission.en.md){ .md-button .md-button--primary}
+
+??? note  "8. When your submitted code does not work"
+
+    If your submitted code does not work, look at `aichallenge-racingkart/output/$DATE-$TIME/d$DOMAIN_ID/autoware.log`.
+
+    ```log
+    [INFO] [launch]: All log files can be found below $USER/.ros/log/$DATE-$TIME-817891-XXX
+    [INFO] [launch]: Default logging verbosity is set to INFO
+    [INFO] [launch.user]: The arguments for aichallenge_system_launch.
+    [INFO] [launch.user]:  - simulation: true
+    [INFO] [launch.user]:  - use_sim_time: true
+    [INFO] [launch.user]:  - sensor_model: racing_kart_sensor_kit
+    [INFO] [launch.user]:  - launch_vehicle_interface: true
+    [INFO] [launch.user]:  - rviz config: /aichallenge/workspace/install/aichallenge_system_launch/share/aichallenge_system_launch/config/autoware.rviz
+    ↓↓↓↓↓↓↓↓
+    [ERROR] [launch]: Caught exception in launch (see debug for traceback): "package 'aichallenge_submit_launch' not found, searching: ['/aichallenge/workspace/install/simple_trajectory_generator', '/aichallenge/workspace/install/simple_pure_pursuit', '/aichallenge/workspace/install/racing_kart_sensor_kit_description', '/aichallenge/workspace/install/racing_kart_gnss_poser', '/
+    ↑↑↑↑↑↑↑↑
+    ```
+    If that does not solve it, check `aichallenge/workspace/build`, `aichallenge/workspace/install`, `aichallenge/workspace/log` and so on, delete them once, build again, and collect the logs.
+
+
+    If you cannot reproduce the error locally by any method, ask in the questions channel with the following information.
+
+    1. The ID, date/time, etc. from https://aichallenge-board.jsae.or.jp/public/submissions
+    2. The steps you tried locally
+    3. The diff from the original sample code and an explanation of the changes you made
+    4. The log information and anything else you suspect may be relevant
+
+??? note  "9. Try the AI-based practice materials (optional)"
+
+    For those who want to broaden their skills after learning the basics of Autoware, we provide practice materials that use machine learning.
+
+    **Recommended for:**
+
+    - Those who want to try the latest AI techniques, not only conventional methods
+
+    - Those who have time to spare and want to take on additional learning
+
+    - Those interested in the field of autonomous driving × AI
+
+    !!! warning "These materials are entirely optional"
+        These materials have no effect whatsoever on competition scoring. They are purely for those interested in the technology.
+
+    [:material-arrow-right-circle: AI-based practice materials](./ai.md){ .md-button .md-button--primary }

--- a/docs/index.en.md
+++ b/docs/index.en.md
@@ -1,6 +1,6 @@
 description: Official documentation for the Autonomous Driving AI Challenge (Racing Kart): Autoware/ROS 2/AWSIM/Docker-based simulation overview, rules, setup, specs, tutorials, and AI guide.
 
-# Japan Automotive AI Challenge 2026
+# Autonomous Driving AI Challenge 2026
 
 ## FY2026 Videos
 
@@ -9,13 +9,14 @@ description: Official documentation for the Autonomous Driving AI Challenge (Rac
     <ul>
       <li><a href="https://www.youtube.com/watch?v=K_ToeWGitbk">Guide 01: Introduction</a></li>
       <li><a href="https://www.youtube.com/watch?v=5BowSyA8hV8">Guide 02: Autoware</a></li>
-      <li><a href="https://www.youtube.com/watch?v=MabDMP6f-Ek">Talk 1: Launch of the End-to-End AI Category (TIER IV)</a></li>
+      <li><a href="https://www.youtube.com/watch?v=hriSPe97rfQ">Guide 03: End to End AI</a></li>
+      <li><a href="https://www.youtube.com/watch?v=MabDMP6f-Ek">Talk 1: Launch of the End to End AI Division (TIER IV)</a></li>
       <li><a href="https://www.youtube.com/watch?v=cGJK4Zlm11c">Talk 2: Community-born AI Chatbot (TPAC)</a></li>
       <li><a href="https://www.youtube.com/watch?v=fGzGK3MC1Gw">Talk 3: The Wabi-Sabi of the AI Challenge (SUBARU)</a></li>
       <li><a href="https://www.youtube.com/watch?v=jrDxfqbDJd4">Talk 4: GNSS for Autonomous Driving (Nikon-Trimble)</a></li>
       <li><a href="https://www.youtube.com/watch?v=Sh-8HNGfQaw">Talk 5: Toward Social Implementation (AIST)</a></li>
       <li><a href="https://www.youtube.com/watch?v=4YcWzPdrdbE">Talk 6: Cooperative Driving with V2X (UTokyo Tsukada Lab)</a></li>
-      <li><a href="https://www.youtube.com/watch?v=nG4jIycigBo">Talk 7: The World of Autonomous Racing (GMO)</a></li>
+      <li><a href="https://www.youtube.com/watch?v=nG4jIycigBo">Talk 7: The World of Autonomous Racing as Seen by a Robotics Engineer (GMO)</a></li>
     </ul>
   </noscript>
 </div>
@@ -40,46 +41,24 @@ description: Official documentation for the Autonomous Driving AI Challenge (Rac
 
 !!! info
 
-    This competition is a new initiative aimed at discovering and nurturing engineers who will lead the future automotive industry in the new technological domains known as CASE and MaaS.
+    This competition is held as a new initiative to discover and develop the engineers who will lead the automotive industry in the new technology domains known as CASE and MaaS.
 
-    The competition involves not only developing programs for autonomous driving mobility but also competing in driving competitions with these developed programs. It aims to provide a platform for engineers, researchers, and students involved in computer science, AI, software, and information processing to challenge themselves, learn, and create organic connections.
-
-## Objectives
-
-### The Role of the Competition from a Technical Perspective
-
-- Learn SDV (Software Defined Vehicle) development through software integration while understanding hardware
-- Learn Continuous Integration / Continuous Deployment (CI/CD)
-- Conduct development using Open Source Software (OSS) as a platform for innovation towards social implementation
-
-### The Role of the Competition in Human Resource Development
-
-- Promote participation of engineers from various fields
-- Accelerate skill development through the provision of educational content
-- Learn how to develop SDVs by reconciling real machines and simulators
-- Innovate through digital twin simulations
-- Create "aspirations" and "passion and excitement" by combining technical competition with entertainment, using motorsport as a theme
-
-## Overview
-
-### Preliminary Round
-
-The preliminary round will be conducted through online simulations. The competition aims to achieve faster lap times on the course using AWSIM, which is oriented towards digital twin simulations. Participants will not only learn the structure of Autoware but also adjust parameters for behavior and decision-making parts and develop new algorithms as needed.
-
-### Final Round
-
-The final competition will be conducted using an EV racing kart as the competition vehicle. Participants will apply the knowledge gained from simulations to real vehicles and tackle challenges unique to real vehicles that cannot be replicated in AWSIM.
-
-For example, participants will be challenged to adjust parameters for application to real vehicles and develop algorithms for noise handling and delay countermeasures that cannot be replicated in simulations.
-
-## Awards
-
-<!-- The total prize money is over 1 million yen. For details, please refer to the [racingkart Autonomous Driving AI Challenge Overview](https://www.jsae.or.jp/jaaic/racingkartver/summary/). -->
-
-## Vehicle
-
-![TOM'S Racing Kart](./assets/racing-kart.jpeg)
+    The competition goes as far as a driving competition in which the programs you develop are loaded onto autonomous mobility. It aims to be a place for engineers, researchers and students in computer science, AI, software and information processing to take on challenges, to provide learning opportunities, and to build organic connections.
 
 ## Challenges
 
-The racing kart will drive around a circuit course and compete for the time it takes to complete a set number of laps. Although the karts will be driving alone this time, in the future they will be driving together with others. Therefore, there is a challenge to avoid virtual objects placed on the course.
+### Preliminaries
+
+Teams compete in fast driving on the course in an online simulation using AWSIM. Participants learn the structure of Autoware and aim to improve performance through parameter tuning and new algorithm development.
+
+### Finals
+
+A real-vehicle competition is held using EV racing karts. Building on what they learned in simulation, participants take on challenges that AWSIM cannot reproduce, such as handling real-vehicle noise and countering latency.
+
+## Competition Overview
+
+!!! info
+
+    Please check the official website for details such as the competition schedule.
+
+    [:material-launch: View the official competition website ](https://www.jsae.or.jp/jaaic/){ .md-button .md-button--primary target="_blank" }

--- a/docs/specifications/hardware.en.md
+++ b/docs/specifications/hardware.en.md
@@ -1,9 +1,41 @@
 # Hardware
 
-| Item | Model                |
-| ---- | -------------------- |
-| CPU  | Intel Core i9-11900H |
-| Mem  | 16 GB                |
-| SSD  | 512 GB               |
-| GNSS | u-blox ZED-F9R       |
-| IMU  | ICM-20948            |
+## Sensor Configuration
+
+| Sensor | Model / Spec | Role |
+| --- | --- | --- |
+| GNSS | u-blox ZED-F9R | Obtains the vehicle's latitude, longitude and altitude by satellite positioning |
+| IMU | ICM-20948 | Measures acceleration and angular velocity (detects the vehicle's attitude and rotation) |
+
+In the preliminaries these are reproduced as virtual sensors in AWSIM.
+
+## PC Configuration (On-Vehicle PC)
+
+| Item | Spec |
+| --- | --- |
+| OS | Ubuntu 22.04 |
+| CPU | Intel Core i9-11900H |
+| Mem | 32 GB |
+| Notes | The vehicle control software also runs on the same ECU |
+
+## PC Configuration (SIM Preliminary Environment)
+
+| Item | Spec |
+| --- | --- |
+| OS | Ubuntu 22.04 |
+| CPU | 16 vCPU Intel Xeon Scalable (Cascade Lake) |
+| Mem | 64 GB |
+| Notes | 3 vCPUs and 12 GiB are allocated to each Autoware |
+
+In the SIM preliminaries, AWSIM and three teams' Autoware instances are launched simultaneously on one instance of the online environment. Because one instance is shared by several teams, ROS_DOMAIN_ID separation and resource allocation are used to prevent interference from other teams' programs.
+
+## PC Configuration (SIM Finals Environment)
+
+| Item | Spec |
+| --- | --- |
+| OS | Ubuntu 22.04 |
+| CPU | Intel Core i7-8700 |
+| Mem | 16 GB |
+| Notes | Lower spec than the recommended environment (for the reason below) |
+
+In the SIM finals, Autoware runs on its own and AWSIM runs on a separate PC, so PCs with the spec above are used. Specifically, the plan is to connect four Autoware PCs to one AWSIM PC for each race.


### PR DESCRIPTION
## 日本語

英語版の `getting-started.en.md`・`specifications/hardware.en.md`・`index.en.md` が 2025 年度の内容のままだったため、現在の日本語版に同期しました。

- ハードウェア: 車両搭載PC（メモリ 32 GB）、SIM予選環境（Autoware あたり 3 vCPU / 12 GiB）、SIM決勝環境（i7-8700 / 16 GB、AWSIM は別PC、Autoware用PC 4台）を追加
- はじめ方: 「2025 年度の登録は終了」を 2026 年度の参加登録フォームに更新、「UPLOAD」を「Submit Code」に修正、404 になっている Google Drive のサンプルリンクを racingkart の Releases に差し替え、日本語版にある手順 4（チームアイコン）・8（ログの確認方法）・9（AI教材、任意）を追加
- トップページ: 2025 年度のタイムアタック形式の説明（「今回は単独走行」）を削除し、日本語版の構成（Concept / Challenges / Competition Overview）に合わせました。動画一覧に E2E 解説動画を追加

`mkdocs build` の警告は増えていません（前後とも19件、内容も同一）。

補足: SIM決勝PCの仕様は `specifications/hardware.en.md` に直接記載しており、`competition/sim-finals-pc.en.md` へのリンクは追加していません。このページは現時点で本ブランチに存在しないためです（英語版は別PR #78 で追加予定）。#78 がマージされた際に、必要であれば相互リンクを追加することを推奨します。

## English

The English `getting-started.en.md`, `specifications/hardware.en.md` and `index.en.md` still carried 2025 content. This syncs them with the current Japanese pages.

- Hardware: add the on-vehicle PC (32 GB), the SIM-qualifying instance (3 vCPU / 12 GiB per Autoware), and the SIM-finals PC (i7-8700 / 16 GB, AWSIM on a separate PC, four Autoware PCs).
- Getting started: "2025 registration closed" updated to the 2026 registration form; "UPLOAD" corrected to "Submit Code"; the 404 Google Drive sample link replaced with the racingkart Releases page; added JA steps 4 (team icon), 8 (log troubleshooting), and 9 (optional AI practice materials).
- Top page: removed the 2025 time-attack wording ("karts will be driving alone this time") and followed the JA structure (Concept / Challenges / Competition Overview); added the E2E guide video.

### Dependency note

`specifications/hardware.en.md` now contains the SIM-finals PC spec (i7-8700 / 16 GB, four Autoware PCs per AWSIM PC) written out directly, sourced from `competition/sim-finals-pc.ja.md`. It does not link to `competition/sim-finals-pc.en.md` because that page does not exist on this branch yet; the English version is proposed separately in our open PR #78 (which also updates the mkdocs nav). Once #78 lands, a cross-link between the two pages could be added as a small follow-up, but this PR does not depend on it and introduces no broken links.

### Verification

Before:
```
19 WARNING lines (see baseline)
```
After:
```
19 WARNING lines, identical to baseline (no new warnings)
```

```
grep -c 'i7-8700' /tmp/site-13/en/specifications/hardware.html   -> 1
grep -c 'driving alone' /tmp/site-13/en/index.html               -> 0
grep -c '2025' /tmp/site-13/en/getting-started.html              -> 3 (all from an embedded Font Awesome SVG copyright comment, unrelated to page content; source markdown has zero occurrences of "2025")
```

`pre-commit run --files docs/specifications/hardware.en.md docs/getting-started.en.md docs/index.en.md`: all hooks passed (check for merge conflicts, detect private key, fix end of files, mixed line ending, trim trailing whitespace, markdownlint, prettier, Markdown Link Check).

---
Team Hayes (Ajayaditya Lokchandra, Nithisha Venkatesh)

本PRはAIコーディング支援を用いて作成し、上記の確認手順で検証しました。 / Prepared with AI coding assistance and verified with the checks above.
