### PR TITLE
docs(getting-started): replace dead board links

### DIFF
--- a/docs/getting-started.en.md
+++ b/docs/getting-started.en.md
@@ -10,7 +10,7 @@ First, use the online scoring environment, then proceed with [environment setup]
 
 Registration for the 2025 competitions have already been closed.
 
-## Accessing and Submitting to the [Online Scoring Environment](https://aichallenge-board.jsae.or.jp/live)
+## Accessing and Submitting to the [Online Scoring Environment](https://aichallenge-board.jsae.or.jp/public/live)
 
 In this competition, you will upload submission files (compressed source code files) to the online environment, where they will be automatically scored and ranked.
 
@@ -21,7 +21,7 @@ Let's try using the online scoring environment with these four steps!
 
 1. After registering for the Autonomous Driving AI Challenge, login information will be sent to your registered email address.
 
-2. Access the [online scoring environment](https://aichallenge-board.jsae.or.jp/live) and log in using the credentials provided in the email.
+2. Access the [online scoring environment](https://aichallenge-board.jsae.or.jp/public/live) and log in using the credentials provided in the email.
 
 3. Once you have access, try submitting a source code file. Download the sample code compressed file from the red button below.
 
@@ -44,5 +44,5 @@ Let's start developing by following the link above!
 
 ## [Submitting Your Source Code](./competition/submission.en.md)
 
-Submit your completed code via the [online scoring environment](https://aichallenge-board.jsae.or.jp/live).
+Submit your completed code via the [online scoring environment](https://aichallenge-board.jsae.or.jp/public/live).
 Set up your submission using the link above.

--- a/docs/getting-started.ja.md
+++ b/docs/getting-started.ja.md
@@ -40,7 +40,7 @@
     チームのアイコンの設定をお願いいたします。アイコンの作成においては、ChatGPTなどの生成AIを活用するのも効果的です。
     作成したアイコンは、SDVスキル標準に基づいた保有スキルの一覧表にも掲載されます。
 
-    [:material-launch: 参加者の保有スキル](https://aichallenge-board.jsae.or.jp/public/jobs){ .md-button .md-button--primary}
+    [:material-launch: 参加者の保有スキル](https://aichallenge-board.jsae.or.jp/public/team){ .md-button .md-button--primary}
 
 ??? note  "5. AIチャレンジの環境構築"
 
@@ -55,11 +55,11 @@
 
     環境構築が完了したら、実際に自動運転ソフトウェアを改良してみましょう。
 
-    [:material-arrow-right-circle: AIチャレンジでの開発の進め方](./development/workspace-usage.ja.md){ .md-button .md-button--primary }
+    [:material-arrow-right-circle: AIチャレンジでの開発の進め方](./development/development-guide.ja.md){ .md-button .md-button--primary }
 
 ??? note  "7. 開発したコードを提出"
 
-    完成したコードの提出は[オンライン採点環境](https://aichallenge-board.jsae.or.jp/live)から行います。
+    完成したコードの提出は[オンライン採点環境](https://aichallenge-board.jsae.or.jp/public/live)から行います。
     下記リンクより再度提出してみましょう。
 
     [:material-launch: ソースコードの提出](./competition/submission.ja.md){ .md-button .md-button--primary}
@@ -86,7 +86,7 @@
 
     手元でどの方法でもエラーが再現できない場合は、下記の情報と共に質問チャンネルでお問い合わせください。
 
-    1. https://aichallenge-board.jsae.or.jp/public/submissions のID、日時などの情報
+    1. オンライン採点環境の「Your Submissions」に表示される提出のID、日時などの情報
     2. 手元でやってみたことの手順の共有
     3. もともとのサンプルコードとの差分、どのような変更を加えたのかの説明
     4. ログの情報、その他思い当たる節がありそうな部分の共有


### PR DESCRIPTION
## 概要

「はじめ方」ページ（日本語版）のリンクのうち、`/public/jobs` と `/public/submissions` が 404 になっていました。保有スキルのボタンをオンライン環境のトップページからリンクされている `/public/team` に変更し、問い合わせ時の提出IDの案内は「Your Submissions」の表示を参照する文章に変更しました。あわせて、リダイレクト用スタブページ（`workspace-usage.ja.md`、メタリフレッシュで `development-guide.html` に転送されるだけのページ）経由のリンクを `development-guide.ja.md` に直接リンクするよう変更し、`/live`（308 リダイレクト）を正規の `/public/live` に変更しました。英語版（`getting-started.en.md`）にも同じ `/live` へのリンクが3箇所あったため、同様に `/public/live` に修正しました（英語版には `/public/jobs` や `/public/submissions` に相当するリンクはありません）。

## 確認

`curl` で旧URLの状態を確認しました。

- `/public/jobs` : 404
- `/public/submissions` : 404
- `/public/team` : 200
- `/public/live` : 200
- `/live` : 308（`/public/live` へのリダイレクト）

`mkdocs build` の WARNING 数は変更前後で同一（19件、いずれも本カードと無関係な既存の警告）でした。`pre-commit` の全チェック（markdownlint, prettier, Markdown Link Check 等）はパスしています。`/public/team` がスキル一覧のページであることは、ブラウザでの目視確認をお願いします。

---

## Summary

Two links on the getting-started page (Japanese), `/public/jobs` and `/public/submissions`, return 404. The skills button now points at `/public/team` (linked from the board's home page), and the support-request step now describes where the submission ID is shown ("Your Submissions") instead of linking the dead URL. It also links the development guide directly instead of going through the `workspace-usage.ja.md` redirect stub (a meta-refresh page that forwards to `development-guide.html`), and replaces the `/live` link (a 308 redirect) with the canonical `/public/live`. The English page (`getting-started.en.md`) has the same `/live` link in three places, so those were updated to `/public/live` as well (it has no equivalent to the `/public/jobs` or `/public/submissions` links).

## Checks

`curl` results for the URLs involved:

- `/public/jobs`: 404
- `/public/submissions`: 404
- `/public/team`: 200
- `/public/live`: 200
- `/live`: 308 (redirects to `/public/live`)

`mkdocs build` WARNING count is unchanged before and after this change (19, all pre-existing and unrelated to this fix). `pre-commit` (markdownlint, prettier, Markdown Link Check, etc.) passes on the changed files. Please confirm in a browser that `/public/team` is in fact the skills-list page.

---
Team Hayes (Ajayaditya Lokchandra, Nithisha Venkatesh)

本PRはAIコーディング支援を用いて作成し、上記の確認手順で検証しました。 / Prepared with AI coding assistance and verified with the checks above.
