### PR TITLE
docs(specifications): document launch options and modes used by simulator_scripts

### DIFF
--- a/docs/development/commands.ja.md
+++ b/docs/development/commands.ja.md
@@ -12,6 +12,8 @@
 | `./setup.bash pull image` | Autoware ベースイメージを `docker pull` します |
 | `./setup.bash download awsim` | AWSIM.zip をダウンロードして展開します |
 | `./setup.bash env` | `.env.example` から `.env` を作成します |
+| `./setup.bash network tune` | DDS 用のホスト設定（`rmem_max`・ループバックのマルチキャスト）を永続化します（sudo が必要） |
+| `./setup.bash network if [name]` | ネットワークインターフェースを `cyclonedds.xml` に追加します。名前を省略すると、このスクリプトで追加したインターフェースをすべて削除します |
 
 ## create_submit_file.bash
 

--- a/docs/specifications/simulator.ja.md
+++ b/docs/specifications/simulator.ja.md
@@ -24,9 +24,11 @@
 | `e2e-final` | `make simulator-e2e-final` | E2E 決勝 | 4台・6周・420秒・sync開始・ハンディキャップ/ランキング on・エンジン音 on |
 | `s2r-final` | `make simulator-s2r-final` | S2R 決勝 | 4台・6周・420秒・sync開始・ハンディキャップ/ランキング on・エンジン音 on・オーバーテイクレーン on |
 | `eval` | `make eval` | 評価（提出時と同じ条件） | 1台・6周・600秒・sync開始 |
-| `parallel` | `make simulator-parallel` | 複数台レース | 3台・6周・600秒・sync開始 |
-| `gate` | `make gate1`〜`make gate3` | セーフティゲートのテスト | 1台・シナリオ別 |
+| `parallel` | `make simulator-parallel` | 複数台レース | 3台・6周・600秒・sync開始・ハンディキャップ/ランキング on・**車両同士の衝突判定 off** |
+| `gate` | `make gate1`〜`make gate3`（`make simulator-gate` は test1〜3 を順次実行・AWSIM のみ） | セーフティゲートのテスト | 1台・シナリオ別 |
 | `multiplay-host` / `multiplay-client` | `make simulator-multiplay-host` など | 通信対戦（[Multiplay](../development/multiplay.ja.md)） | - |
+| `multiplay-server` | `make simulator-multiplay-server` | 通信対戦の専用サーバー | `-batchmode -nographics`・port 7777 |
+| `sample-scenario` | `make simulator-sample-scenario` | シナリオを指定して起動 | `StreamingAssets/Race/official.yaml` を `--scenario` で読み込み |
 | `simulator`（既定） | `make simulator` | 引数なしの素起動 | 起動時UIで設定を選択 |
 
 ### 部門ごとのモード（E2E / S2R） { #class-modes }
@@ -87,6 +89,8 @@ AWSIMはコマンドライン引数で動作を制御でき、起動スクリプ
 | --handicap    | bool   | false      | 順位に応じたハンディキャップの有効/無効を設定します。 |
 | --start-random | bool  | false      | 開始位置のランダム化の有効/無効を設定します。     |
 | --overtaking-lane | bool | false    | オーバーテイクレーンのBLOCKペナルティ判定の有効/無効を設定します（[ルール](../competition/sw-class.ja.md#overtake-lane)）。 |
+| --venue       | string |            | コース（会場）を指定します。起動スクリプトでは `citycircuit` を指定しています。 |
+| --safety-gate | string |            | セーフティゲートのテストを実行します。`1`/`2`/`3`/`all`（`all` は test1〜3 を順次実行）。`gate.sh` で使用しています。 |
 
 ### 制御・入力設定
 
@@ -130,6 +134,8 @@ AWSIMはコマンドライン引数で動作を制御でき、起動スクリプ
 | --multiplay-port        | int    | 50051      | 通信ポート番号。                            |
 | --multiplay-name        | string |            | プレイヤー名。                              |
 | --multiplay-send-hz     | float  | 50.0       | 送信更新頻度（Hz）。                        |
+| --multiplay-vehicle-index | int  |            | 自分が操作する車両の番号。`multiplay-host.sh` / `multiplay-client.sh` では `1`。`--vehicles` はこの値以上にしてください。 |
+| --multiplay-network-id  | int    | 0          | ネットワークID。`0` で自動採番されます。     |
 
 ### オーディオ
 
@@ -139,6 +145,9 @@ AWSIMはコマンドライン引数で動作を制御でき、起動スクリプ
 
 !!! tip "真偽値オプション"
     真偽値オプションは `1`/`true`/`on`/`enable`/`enabled` または `0`/`false`/`off`/`disable`/`disabled` を受け付けます。
+
+!!! tip "Unity 標準の起動引数"
+    AWSIM は Unity 標準の起動引数（シングルダッシュ）も受け付けます。起動スクリプトでは `-batchmode` `-nographics`（`multiplay-server.sh`）、`-screen-fullscreen` `-screen-width` `-screen-height` `-screen-quality` `-window-mode`（`parallel.sh`）を使用しています。
 
 ## キーボード操作
 


### PR DESCRIPTION
## 概要

起動スクリプト（`simulator_scripts/*.sh`）で使われているのに仕様ページに無かった項目を追記します。

- `parallel` モードは車両同士の衝突判定が off（`parallel.sh`）であることを明記
- `make simulator-gate`（test1〜3 を順次実行）、`multiplay-server` / `sample-scenario` モードを追加
- `--venue`、`--safety-gate`、`--multiplay-vehicle-index`、`--multiplay-network-id` をオプション表に追加
- Unity 標準引数（`-batchmode` など）の補足
- コマンド一覧に `./setup.bash network tune` / `network if` を追加

既定値は AWSIM 側にあり確認できないため、推測では書いていません。

対象ファイル: `docs/specifications/simulator.ja.md`（モード表、オプション表、Unity 起動引数の Tip）、`docs/development/commands.ja.md`（`setup.bash` コマンド一覧）。

検証: mkdocs build の WARNING 件数は変更前後で 19 件のまま（新規警告 0 件）。pre-commit（markdownlint / prettier / markdown-link-check ほか）はすべて Passed。

他PRとの重複について: 弊チームのオープンPR #76 も `specifications/simulator.ja.md` を編集していますが（overtaking-lane の BLOCK ペナルティに関する警告文の追加）、対象は既存の `--overtaking-lane` 行そのもので、本PRはその直後に新規の `--venue` / `--safety-gate` 行を追加するのみのため、行の重複はありません。DOCS-01（`simulator.en.md` の再同期、別ワークツリーで対応中）は英語版ファイルのみを対象とし、本PRは日本語版のみを対象とするため直接の衝突はありません。マージ順序によりコンテキスト行がずれる可能性はありますが、その解消はコーディネーターが行います。

## Summary

Adds what `simulator_scripts/*.sh` use but the spec page did not document:

- `parallel` mode runs with vehicle-vehicle collisions off (`parallel.sh`)
- `make simulator-gate` (runs test1-3 in sequence) and the `multiplay-server` / `sample-scenario` modes
- `--venue`, `--safety-gate`, `--multiplay-vehicle-index`, `--multiplay-network-id` in the option tables
- a note on Unity's single-dash arguments (`-batchmode` etc.)
- `./setup.bash network tune` / `network if` in the command list

Defaults live in the AWSIM binary and cannot be checked here, so none are guessed.

Files touched: `docs/specifications/simulator.ja.md` (mode table, option tables, Unity launch-argument tip) and `docs/development/commands.ja.md` (`setup.bash` command list).

Verification: mkdocs build WARNING count unchanged before/after (19, 19; 0 new warnings). pre-commit (markdownlint, prettier, markdown-link-check, etc.) all passed.

Overlap with our other PRs: our open PR #76 also edits `specifications/simulator.ja.md` (adds a warning note to the existing `--overtaking-lane` row), but this PR only adds new `--venue` / `--safety-gate` rows immediately after it, so there is no line-level conflict. DOCS-01 (`simulator.en.md` resync, handled in a separate worktree) only touches the English file, while this PR only touches the Japanese file, so there is no direct overlap; any adjacent-context shift at merge time will be resolved by the coordinator.

---
Team Hayes (Ajayaditya Lokchandra, Nithisha Venkatesh)

本PRはAIコーディング支援を用いて作成し、上記の確認手順で検証しました。 / Prepared with AI coding assistance and verified with the checks above.
