### PR TITLE
docs(ai): add English translation of the AI course landing page

### DIFF
--- a/docs/ai.en.md
+++ b/docs/ai.en.md
@@ -1,0 +1,25 @@
+# AI Course
+
+## Overview
+
+This competition has an End to End AI Division. In this division, you are required to achieve autonomous driving by taking camera images and LiDAR data as input and outputting control signals (or a trajectory).
+
+To help participants acquire basic knowledge and development tips, this page introduces the main AI algorithms and explains how to use the provided packages. Modify these samples, or use them as a reference to implement new nodes.
+
+![ai_image](assets/ai_image.png)
+
+## AI Packages
+
+The AI packages provided for this competition are listed below. Packages already integrated with Autoware can be run by switching the `control_method` setting. Training scripts for the models are also provided, so you can improve the models yourself. For concrete usage, see the usage page of each model. Details of each algorithm are summarized in [Algorithms](./ml_sample/algorithms.md).
+
+| Model | Input sensors | Output | Package | Description |
+|---|---|---|---|---|
+| TinyLidarNet | LiDAR | Control signal | tiny_lidar_net_controller | [Usage](./ml_sample/tiny_lidar_net.md) |
+| PilotNet | Camera | Control signal | pilot_net_controller | [Usage](./ml_sample/pilot_net.md) |
+| Soft Actor-Critic (reinforcement learning) | Camera, vehicle speed | Control signal | rl_train_controller | [Usage](./ml_sample/soft_actor_critic.md) |
+| VLM Planner | Camera | Trajectory | --- | [Usage](./ml_sample/vlm_setup.md) |
+| VAD Planner | Camera | Trajectory | --- | [Usage](./ml_sample/vad_setup.md) |
+
+### Notes
+
+- VLM Planner and VAD Planner are not integrated with the Autoware used in the 2026 competition. To use them, you need to bring them into the 2026 competition environment yourself. For design and implementation details, see [Sample ROS Node (VLM Planner)](./ml_sample/ai_sample_node_vlm.md).


### PR DESCRIPTION
## 日本語

AI講座のトップページ（`ai.ja.md`）の英語版 `ai.en.md` を追加します。英語サイトの ML タブを開くと現在は日本語ページが表示されます。提供 AI パッケージ一覧（TinyLidarNet / PilotNet / SAC / VLM / VAD）と `control_method` での切り替え方法が英語で読めるようになります。リンク先の `ml_sample/*.md` は変更していません。nav の変更は不要です（`ai.md` は既にサフィックスなしで、`nav_translations` が EN タブのタイトルを与えています）。

## English

Adds `ai.en.md`, an English translation of the AI course landing page. Opening the ML tab of the English site currently shows the Japanese page. The table of provided AI packages (TinyLidarNet / PilotNet / SAC / VLM / VAD) and the note about switching via `control_method` are now readable in English. Links to `ml_sample/*.md` are unchanged; no nav change is needed (`ai.md` is already suffix-less, and `nav_translations` already supplies the EN tab title).

**Checks run:**
- `mkdocs build` warnings: 19 before, 19 after (identical set; this file adds 0 warnings). `site/en/ai.html` is generated correctly.
- `pre-commit run --files docs/ai.en.md`: all hooks passed (markdownlint, prettier, Markdown Link Check, etc.).

---
Team Hayes (Ajayaditya Lokchandra, Nithisha Venkatesh)

本PRはAIコーディング支援を用いて作成し、上記の確認手順で検証しました。 / Prepared with AI coding assistance and verified with the checks above.
