### PR TITLE
docs(community): add Team Hayes articles and toolkit

### DIFF
--- a/docs/community.en.md
+++ b/docs/community.en.md
@@ -14,6 +14,12 @@ Team Hayes: [a self-localisation trap where argmin jumps to the opposite leg (Qi
 
 Team Hayes: [starter-kit traps and the PRs that fix them (Zenn, JA/EN)](https://zenn.dev/ajayaditya/articles/aichallenge-starter-kit-traps-2026)
 
+Team Hayes: [the quaternion's z is not the yaw angle (Qiita, JA/EN)](https://qiita.com/TeamHayes/items/f004f15b7c0fe1f4b512)
+
+Team Hayes: [lowering v_max made the kart faster: a km/h and m/s mix-up (Qiita, JA/EN)](https://qiita.com/TeamHayes/items/934870c19786e3e6b3fe)
+
+Team Hayes: [lessons from building with 100 AI agents (Zenn, JA/EN)](https://zenn.dev/ajayaditya/articles/100-ai-agents-racing-lessons)
+
 Team Hayes: [aichallenge-toolkit, ROS-free tools for rosbag analysis and pre-submit checks](https://github.com/theCodeForgerHQ/aichallenge-toolkit)
 
 We are actively seeking contributions!!!

--- a/docs/community.en.md
+++ b/docs/community.en.md
@@ -20,6 +20,8 @@ Team Hayes: [lowering v_max made the kart faster: a km/h and m/s mix-up (Qiita, 
 
 Team Hayes: [lessons from building with 100 AI agents (Zenn, JA/EN)](https://zenn.dev/ajayaditya/articles/100-ai-agents-racing-lessons)
 
+Team Hayes: [making the challenge readable without Japanese: docs and tools in English (Qiita, JA/EN)](https://qiita.com/TeamHayes/items/7aaf06afe8f39d8f6dfd)
+
 Team Hayes: [aichallenge-toolkit, ROS-free tools for rosbag analysis and pre-submit checks](https://github.com/theCodeForgerHQ/aichallenge-toolkit)
 
 We are actively seeking contributions!!!

--- a/docs/community.en.md
+++ b/docs/community.en.md
@@ -10,6 +10,12 @@
 
 <https://www.ritsumei.ac.jp/ise/suki_ict/story01.html/>
 
+Team Hayes: [a self-localisation trap where argmin jumps to the opposite leg (Qiita, JA/EN)](https://qiita.com/TeamHayes/items/2bd248ad00a8011406f4)
+
+Team Hayes: [starter-kit traps and the PRs that fix them (Zenn, JA/EN)](https://zenn.dev/ajayaditya/articles/aichallenge-starter-kit-traps-2026)
+
+Team Hayes: [aichallenge-toolkit, ROS-free tools for rosbag analysis and pre-submit checks](https://github.com/theCodeForgerHQ/aichallenge-toolkit)
+
 We are actively seeking contributions!!!
 
 ## Finals Video

--- a/docs/community.ja.md
+++ b/docs/community.ja.md
@@ -68,6 +68,7 @@
 [:material-launch: Team Hayes: quaternion の z を yaw だと思っていませんか（Qiita）](https://qiita.com/TeamHayes/items/f004f15b7c0fe1f4b512){ .md-button .md-button--primary target="_blank" }
 [:material-launch: Team Hayes: v_max を下げたら速くなった（Qiita）](https://qiita.com/TeamHayes/items/934870c19786e3e6b3fe){ .md-button .md-button--primary target="_blank" }
 [:material-launch: Team Hayes: AI エージェント 100 体で学んだこと（Zenn）](https://zenn.dev/ajayaditya/articles/100-ai-agents-racing-lessons){ .md-button .md-button--primary target="_blank" }
+[:material-launch: Team Hayes: 日本語が読めなくても参加できるように、ドキュメントとツールを英語対応した話（Qiita）](https://qiita.com/TeamHayes/items/7aaf06afe8f39d8f6dfd){ .md-button .md-button--primary target="_blank" }
 [:material-launch: Team Hayes: aichallenge-toolkit（ROS なしで rosbag を解析するツール集）](https://github.com/theCodeForgerHQ/aichallenge-toolkit){ .md-button .md-button--primary target="_blank" }
 
 <div class="community-callout">

--- a/docs/community.ja.md
+++ b/docs/community.ja.md
@@ -63,6 +63,9 @@
 
 [:material-launch: Team Panasonic Automotive Challengersの活躍を見る](https://automotive.panasonic.com/newsroom/jaaic){ .md-button .md-button--primary target="_blank" }
 [:material-launch: Team Rits-Autoの活躍を見る](https://www.ritsumei.ac.jp/ise/suki_ict/story01.html/){ .md-button .md-button--primary target="_blank" }
+[:material-launch: Team Hayes: argmin で逆向きの区間に飛ぶ自己位置の罠（Qiita）](https://qiita.com/TeamHayes/items/2bd248ad00a8011406f4){ .md-button .md-button--primary target="_blank" }
+[:material-launch: Team Hayes: スターターキットで踏んだ罠と直した PR（Zenn）](https://zenn.dev/ajayaditya/articles/aichallenge-starter-kit-traps-2026){ .md-button .md-button--primary target="_blank" }
+[:material-launch: Team Hayes: aichallenge-toolkit（ROS なしで rosbag を解析するツール集）](https://github.com/theCodeForgerHQ/aichallenge-toolkit){ .md-button .md-button--primary target="_blank" }
 
 <div class="community-callout">
   <p>絶賛募集中！！！</p>

--- a/docs/community.ja.md
+++ b/docs/community.ja.md
@@ -65,6 +65,9 @@
 [:material-launch: Team Rits-Autoの活躍を見る](https://www.ritsumei.ac.jp/ise/suki_ict/story01.html/){ .md-button .md-button--primary target="_blank" }
 [:material-launch: Team Hayes: argmin で逆向きの区間に飛ぶ自己位置の罠（Qiita）](https://qiita.com/TeamHayes/items/2bd248ad00a8011406f4){ .md-button .md-button--primary target="_blank" }
 [:material-launch: Team Hayes: スターターキットで踏んだ罠と直した PR（Zenn）](https://zenn.dev/ajayaditya/articles/aichallenge-starter-kit-traps-2026){ .md-button .md-button--primary target="_blank" }
+[:material-launch: Team Hayes: quaternion の z を yaw だと思っていませんか（Qiita）](https://qiita.com/TeamHayes/items/f004f15b7c0fe1f4b512){ .md-button .md-button--primary target="_blank" }
+[:material-launch: Team Hayes: v_max を下げたら速くなった（Qiita）](https://qiita.com/TeamHayes/items/934870c19786e3e6b3fe){ .md-button .md-button--primary target="_blank" }
+[:material-launch: Team Hayes: AI エージェント 100 体で学んだこと（Zenn）](https://zenn.dev/ajayaditya/articles/100-ai-agents-racing-lessons){ .md-button .md-button--primary target="_blank" }
 [:material-launch: Team Hayes: aichallenge-toolkit（ROS なしで rosbag を解析するツール集）](https://github.com/theCodeForgerHQ/aichallenge-toolkit){ .md-button .md-button--primary target="_blank" }
 
 <div class="community-callout">


### PR DESCRIPTION
## 概要
コミュニティページの「自動運転AIチャレンジの取り組みの記事」に、Team Hayes の記事 2 本とツール集へのリンクを追加します（日本語版はボタン、英語版はリンク）。

- Qiita: 最近傍 waypoint の argmin が 1.5 m で逆向きの区間に飛ぶ（#313 / aichallenge-racingkart #314 の解説）
- Zenn: make eval が止まる・提出物が入れ替わる、スターターキットで踏んだ罠と直した PR（#276, #315-#320 の解説）
- aichallenge-toolkit: ROS なしで rosbag（mcap）を解析するツールと提出前チェック（Apache-2.0、テスト 300 件）

ページ末尾の「絶賛募集中！！！」を見て追加しました。記事はどれも日本語と英語の両方で書いています。形式が合わなければ直しますのでご指摘ください。

`mkdocs build` の WARNING 数は変わりません（19 件）。

## Summary
Adds links to two Team Hayes articles and our toolkit under "Articles on Autonomous Driving AI Challenge Efforts" on the community page (buttons on the Japanese page, plain links on the English page, matching each page's existing style).

- Qiita: a self-localisation trap where argmin jumps to the opposite leg (explains #313 and racingkart #314)
- Zenn: starter-kit traps and the PRs that fix them (explains #276 and #315-#320)
- aichallenge-toolkit: ROS-free tools for rosbag (mcap) analysis and pre-submit checks (Apache-2.0, 300 tests)

Added in response to the page's call for contributions. Both articles are written in Japanese and English. Happy to adjust the format.

`mkdocs build` warnings are unchanged (19).

---
Team Hayes (Ajayaditya Lokchandra, Nithisha Venkatesh)
