### PR TITLE
docs(competition): add alt text to the submission page screenshots

### DIFF
--- a/docs/competition/submission.en.md
+++ b/docs/competition/submission.en.md
@@ -47,20 +47,20 @@ Submit to the online environment using the following steps:
 3. Submit to the online scoring environment
 
     Access the [online environment](https://aichallenge-board.jsae.or.jp).
-    <img src="./images/topImage.png" width="100%">
+    <img src="./images/topImage.png" width="100%" alt="Top page of the AI Challenge online environment, with the Public Dashboard and Login buttons at the top right">
 
     Log in from the "Login" button in the top right.
-    <img src="./images/siteImage1.png" width="100%">
+    <img src="./images/siteImage1.png" width="100%" alt="Sign-in page: username and password fields on the right, sponsor logos on the left">
 
     Once logged in, upload `aichallenge_submit.tar.gz` using the "Submit Code" button. After uploading, the source code will be built and simulation will be run in sequence.
-    <img src="./images/siteImage2.png" width="100%">
+    <img src="./images/siteImage2.png" width="100%" alt="Dashboard Overview screen, with a red arrow pointing to the Submit Code button at the top right">
 
     On the upload screen, select the `aichallenge_submit.tar.gz` to upload. You can optionally add a comment. You can also change the rank range of the opponent to challenge — by default you battle the team one rank above you. Widening the range lets you challenge higher-ranked teams, with a larger rating gain if you win. Choose strategically.
 
     If successful, "Success" will be displayed.
     If the build fails, the launch fails, or the score is not output, "Failed" will be displayed. In this case, please re-upload as there may be an internal server error. Contact us via Slack if the problem persists.
 
-    <img src="./images/siteImage3.png" width="100%">
+    <img src="./images/siteImage3.png" width="100%" alt="Submit Code dialog: today's submission count, the matchmaking range slider (+0 to +5), the file upload area, a comment box and the Submit & Challenge button">
 
 ## Checking Results
 
@@ -68,9 +68,9 @@ Submit to the online environment using the following steps:
 - Detailed race data including lap times and logs can be checked by clicking the button at the right end of the submission history.
     - You can check `result-summary.json`, rosbag, and `autoware.log`.
 
-    <img src="./images/siteImage4.png" width="100%">
+    <img src="./images/siteImage4.png" width="100%" alt="Your Submissions list, with a red arrow pointing to the eye icon that opens the details">
 
-    <img src="./images/siteImage5.png" width="100%">
+    <img src="./images/siteImage5.png" width="100%" alt="Submission Details screen: submission ID, submission time, user ID, group ID, build ID, state and the result JSON">
 
 ## If Failed
 

--- a/docs/competition/submission.ja.md
+++ b/docs/competition/submission.ja.md
@@ -45,16 +45,16 @@ Queued（受付済み） → Building（ビルド中） → Running（シミュ�
 3. オンライン採点環境への提出
 
     [オンライン環境](https://aichallenge-board.jsae.or.jp)にアクセスします。
-    <img src="./images/topImage.png" width="100%">
+    <img src="./images/topImage.png" width="100%" alt="自動運転AIチャレンジのオンライン環境トップページ。右上に Public Dashboard と Login のボタンがある">
 
     右上の「Login」 ボタンからログインします。
-    <img src="./images/siteImage1.png" width="100%">
+    <img src="./images/siteImage1.png" width="100%" alt="ログインページ。右側にユーザー名とパスワードの入力欄、左側に協賛企業のロゴ">
 
     ログインが完了したら「Submit Code」ボタンでアップロードを行います。
-    <img src="./images/siteImage2.png" width="100%">
+    <img src="./images/siteImage2.png" width="100%" alt="ダッシュボードの Overview 画面。右上の Submit Code ボタンを赤い矢印で示している">
 
     アップロード画面では、アップロードする`aichallenge_submit.tar.gz` を選択します。任意でコメントを記載出来ます。また、対戦相手のレートの範囲を変更することが出来ます。デフォルトはランクが1つ上のチームと対戦します。範囲を広げることで、より上位ランクのチームと対戦する可能性がありますが、勝利したときのレートの上がり幅が大きくなります。戦略を練って設定しましょう。
-    <img src="./images/siteImage3.png" width="100%">
+    <img src="./images/siteImage3.png" width="100%" alt="Submit Code ダイアログ。本日の提出回数、対戦相手の範囲スライダー（+0〜+5）、ファイルのアップロード欄、コメント欄、Submit & Challenge ボタン">
 
 ## 結果の確認手順
 
@@ -64,9 +64,9 @@ Queued（受付済み） → Building（ビルド中） → Running（シミュ�
     - `result-summary.json`、rosbag、`autoware.log`を確認することができます
     - 画面右上の「Copy Public Link」によってSNSでの共有用リンクを取得できます
 
-    <img src="./images/siteImage4.png" width="100%">
+    <img src="./images/siteImage4.png" width="100%" alt="Your Submissions の一覧。詳細を開く目のアイコンを赤い矢印で示している">
 
-    <img src="./images/siteImage5.png" width="100%">
+    <img src="./images/siteImage5.png" width="100%" alt="Submission Details 画面。提出 ID、提出時刻、ユーザー ID、グループ ID、ビルド ID、状態、結果の JSON">
 
 ## Failedの場合
 
@@ -112,4 +112,4 @@ Queued（受付済み） → Building（ビルド中） → Running（シミュ�
     - Submissions
         - コードの提出履歴が表示されます。ログの確認やROSBAGダウンロードはここで行えます
 
-<img src="./images/siteImage6.png" width="100%">
+<img src="./images/siteImage6.png" width="100%" alt="Live 画面。提出数などのカウンター、レース映像、ランキング表、アクティビティ、レート推移のグラフ、提出一覧">


### PR DESCRIPTION
## 概要
提出方法ページ（`competition/submission.{ja,en}.md`）のスクリーンショット 13 枚（日本語 7、英語 6）に `alt` 属性がなく、スクリーンリーダーでは画像の内容が読み上げられませんでした。各画像に、何が写っているか・どこを示しているかを説明する代替テキストを付けました（日本語ページは日本語、英語ページは英語）。

- 例: 「Submit Code ダイアログ。本日の提出回数、対戦相手の範囲スライダー（+0〜+5）、ファイルのアップロード欄…」
- 表示は変わりません。`mkdocs build` の WARNING 数も変わりません（19 件）。
- 同じファイルを変更している #87・#98 とは別の行なので、衝突はありません。

## Summary
The 13 screenshots on the submission page (`competition/submission.{ja,en}.md`, 7 in Japanese and 6 in English) had no `alt` attribute, so screen readers could not say what they show. Each now has alt text describing its content and what it points to (Japanese on the Japanese page, English on the English page).

- Example: "Submit Code dialog: today's submission count, the matchmaking range slider (+0 to +5), the file upload area, ..."
- Rendering is unchanged, and `mkdocs build` warnings are unchanged (19).
- #87 and #98 touch the same files on different lines, so there is no conflict.

---
Team Hayes (Ajayaditya Lokchandra, Nithisha Venkatesh)

本PRはAIコーディング支援を用いて作成し、上記の確認手順で検証しました。 / Prepared with AI coding assistance and verified with the checks above.
