### PR TITLE
docs: add a bilingual glossary and a guide for international participants

### DIFF
--- a/docs/glossary.en.md
+++ b/docs/glossary.en.md
@@ -1,0 +1,33 @@
+# Glossary
+
+Terms used in the Japanese pages, rules and Slack, with the English used on this site. Where a rule is involved, the linked rules page is authoritative.
+
+| Japanese | English | Meaning |
+|---|---|---|
+| 自動運転AIチャレンジ | Autonomous Driving AI Challenge | This competition, organised by JSAE |
+| Sim to Real SW部門 | Sim to Real SW division | Improve an Autoware / ROS 2 sample stack that receives V2X data. The only division with a real-vehicle final |
+| End to End AI部門 | End to End AI division | Build a machine-learning driver from camera and 2D LiDAR data |
+| 予選 | Qualifiers | Online matchmaking races in the organisers' simulation environment |
+| SIM決勝 | Simulation final | The on-site final in the simulator |
+| 実機決勝・実車決勝 | Real-vehicle final | The final with real karts (Sim to Real SW division) |
+| 試合 | Match | One race in a final |
+| 走行枠 | Run slot | The time window of a match (for example, 7 minutes of racing) |
+| 周回数 | Lap count | Number of laps completed |
+| 反則 | Foul | A rule violation. In the real-vehicle final, fewer fouls rank higher ([rules](./competition/sw-class.en.md)) |
+| ペナルティ | Penalty | A time-limited restriction for a violation, such as a speed cap |
+| オーバーテイクレーン | Overtaking lane | The overtaking rule used in the finals ([rules](./competition/sw-class.en.md)) |
+| BLOCK | BLOCK | The overtaking-lane violation penalty: 20 seconds limited to 5 km/h, shown on the HUD |
+| ハンディキャップ | Handicap | In the simulator only, acceleration and speed may be handicapped by race position |
+| マッチメイキング | Matchmaking | When submitting, how far above your own rank you choose to challenge |
+| レート・レーティング | Rating | Goes up with wins and down with losses; the ranking is by rating |
+| 提出・提出物 | Submission, submission file | The `aichallenge_submit.tar.gz` you upload ([submission](./competition/submission.en.md)) |
+| NPC | NPC | A car provided by the organisers |
+| 持参PC・持ち込みPC | Your own PC (BYOD) | A PC your team brings to the simulation final ([PC guide](https://automotiveaichallenge.github.io/aichallenge-documentation-racingkart/en/competition/sim-finals-pc.html)) |
+| 運営 | Organisers, staff | The competition organisers |
+| 集合 | Call time | When your team must gather, for example 40 minutes before your match |
+| 台上 | On stage | The stage area where matches are operated |
+| オペレータ | Operator | The team member who operates the PC during a match |
+| 説明員 | Presenter | The team member who explains the team's approach |
+| 緊急停止 | Emergency stop | The organisers may stop a vehicle for safety |
+
+Missing a term? Suggestions are welcome through [Contributing](./contributing.en.md).

--- a/docs/glossary.ja.md
+++ b/docs/glossary.ja.md
@@ -1,0 +1,33 @@
+# 用語集
+
+日本語のページ・ルール・Slack で使われる用語と、このサイトの英語版での表記の対応表です。ルールに関わる内容は、リンク先のルールのページが正です。
+
+| 日本語 | 英語 | 意味 |
+|---|---|---|
+| 自動運転AIチャレンジ | Autonomous Driving AI Challenge | 本大会（主催: 自動車技術会） |
+| Sim to Real SW部門 | Sim to Real SW division | V2X データを受け取る Autoware / ROS 2 のサンプルを改良する部門。実機決勝があるのはこの部門のみ |
+| End to End AI部門 | End to End AI division | カメラと 2D LiDAR のデータから機械学習で走らせる部門 |
+| 予選 | Qualifiers | 運営のオンラインシミュレーション環境でのマッチメイキング対戦 |
+| SIM決勝 | Simulation final | 会場で行うシミュレーターでの決勝 |
+| 実機決勝・実車決勝 | Real-vehicle final | 実際のカートで行う決勝（Sim to Real SW部門） |
+| 試合 | Match | 決勝の 1 レース |
+| 走行枠 | Run slot | 1 試合の時間枠（例: 走行時間 7 分） |
+| 周回数 | Lap count | 完了した周回の数 |
+| 反則 | Foul | ルール違反。実機決勝では反則回数が少ないほど上位（[ルール](./competition/sw-class.ja.md)） |
+| ペナルティ | Penalty | 違反に対する時間つきの制限（速度制限など） |
+| オーバーテイクレーン | Overtaking lane | 決勝で使う追い越しのルール（[ルール](./competition/sw-class.ja.md)） |
+| BLOCK | BLOCK | オーバーテイクレーン違反のペナルティ。20 秒間 5 km/h の速度制限、HUD に表示 |
+| ハンディキャップ | Handicap | SIM 環境のみ、レース内順位によって加速度・速度にハンディキャップがつく場合がある |
+| マッチメイキング | Matchmaking | 提出時に、自チームよりどのくらい上位のチームに挑戦するかを選ぶこと |
+| レート・レーティング | Rating | 勝てば上がり負ければ下がる。レートの高い順にランキングが決まる |
+| 提出・提出物 | Submission, submission file | アップロードする `aichallenge_submit.tar.gz`（[提出方法](./competition/submission.ja.md)） |
+| NPC | NPC | 運営が用意した車両 |
+| 持参PC・持ち込みPC | Your own PC (BYOD) | SIM決勝にチームが持ち込む PC（[PC 環境説明](./competition/sim-finals-pc.ja.md)） |
+| 運営 | Organisers, staff | 大会運営 |
+| 集合 | Call time | チームが集まる時刻（例: 試合の 40 分前） |
+| 台上 | On stage | 試合を操作するステージ上 |
+| オペレータ | Operator | 試合中に PC を操作するメンバー |
+| 説明員 | Presenter | チームの取り組みを説明するメンバー |
+| 緊急停止 | Emergency stop | 安全のため運営が車両を止めることがある |
+
+足りない用語があれば、[コントリビューション](./contributing.ja.md)からお知らせください。

--- a/docs/international.en.md
+++ b/docs/international.en.md
@@ -1,0 +1,30 @@
+# For International Participants
+
+A starting point for teams who do not read Japanese. The documentation is available in Japanese and English; when a page has only Japanese, the English site shows the Japanese page.
+
+## Read these first
+
+1. [Getting Started](./getting-started.en.md): what the competition is and how to begin.
+2. [Recommended Environment](./setup/requirements.en.md) and [Setup](./setup/introduction.en.md): Ubuntu 22.04 is the supported OS.
+3. The rules for your division: [Sim to Real SW](./competition/sw-class.en.md) or [End to End AI](./competition/ai-class.en.md).
+4. [Submission](./competition/submission.en.md): how to upload and how matchmaking works.
+5. For finalists: [SIM Finals](https://automotiveaichallenge.github.io/aichallenge-documentation-racingkart/en/competition/sim-finals.html), [SIM Finals PC guide](https://automotiveaichallenge.github.io/aichallenge-documentation-racingkart/en/competition/sim-finals-pc.html) and [Real-Vehicle Finals](https://automotiveaichallenge.github.io/aichallenge-documentation-racingkart/en/competition/kart-finals.html).
+
+The official schedule and entry information are on the [JSAE competition page](https://www.jsae.or.jp/jaaic/index/overview/).
+
+## Environment
+
+- Use Ubuntu 22.04. If you only have Windows, the [Recommended Environment](./setup/requirements.en.md) page recommends installing Ubuntu, ideally on a separate SSD.
+- Running without a GPU (headless AWSIM) is possible but not officially supported.
+
+## Language tips
+
+- Many terms appear in Japanese in rules, the online environment and Slack. See the [Glossary](./glossary.en.md).
+- If an English page and its Japanese page seem to disagree, check the Japanese page as well and ask in the question channel.
+- Browser translation works well for reading Japanese pages, but keep commands, file names and topic names exactly as written.
+
+## Where to ask
+
+- The [FAQ](./faq.en.md) answers common setup and submission questions, including where to ask anything it does not cover.
+- The organisers' Slack has a question channel. Writing in English is fine; include your environment and the output of `./setup.bash doctor` for setup problems.
+- For a bug in the starter kit, you can open an issue on [aichallenge-racingkart](https://github.com/AutomotiveAIChallenge/aichallenge-racingkart).

--- a/docs/international.ja.md
+++ b/docs/international.ja.md
@@ -1,0 +1,30 @@
+# 海外・日本語以外の参加者向けガイド
+
+日本語を読まない参加チームのための入口のページです（英語版が本文です）。ドキュメントは日本語と英語で提供しており、英語版がないページは英語サイトでも日本語のページが表示されます。
+
+## 最初に読むページ
+
+1. [はじめに](./getting-started.ja.md): 大会の概要と始め方
+2. [推奨環境](./setup/requirements.ja.md)と[環境構築](./setup/introduction.ja.md): 対応 OS は Ubuntu 22.04
+3. 参加部門のルール: [Sim to Real SW部門](./competition/sw-class.ja.md) または [End to End AI部門](./competition/ai-class.ja.md)
+4. [提出方法](./competition/submission.ja.md): アップロードとマッチメイキング
+5. 決勝進出チーム: [SIM決勝](./competition/sim-finals.ja.md)、[SIM決勝 PC 環境説明](./competition/sim-finals-pc.ja.md)、[実機決勝](./competition/kart-finals.ja.md)
+
+公式の日程とエントリー情報は [JSAE の大会ページ](https://www.jsae.or.jp/jaaic/index/overview/)にあります。
+
+## 環境
+
+- Ubuntu 22.04 を使ってください。Windows しかない場合は、[推奨環境](./setup/requirements.ja.md)のとおり、できれば別の SSD に Ubuntu をインストールしてください。
+- GPU なし（AWSIM のヘッドレス実行）でも動かせますが、公式にはサポートされていません。
+
+## 言葉について
+
+- ルール、オンライン環境、Slack には日本語の用語が多く出てきます。[用語集](./glossary.ja.md)を参照してください。
+- 英語版と日本語版の内容が食い違うように見えるときは、日本語版も確認し、質問チャンネルで聞いてください。
+- 日本語ページはブラウザの翻訳で十分読めますが、コマンド・ファイル名・トピック名は書かれたとおりに使ってください。
+
+## 質問するには
+
+- [FAQ](./faq.ja.md)に、よくある質問と、FAQ にない質問の聞き方があります。
+- 運営の Slack に質問チャンネルがあります。英語で書いて構いません。環境構築の質問では、環境と `./setup.bash doctor` の結果も添えてください。
+- スターターキットの不具合は [aichallenge-racingkart](https://github.com/AutomotiveAIChallenge/aichallenge-racingkart) の Issue でも報告できます。

--- a/mkdocs.yaml
+++ b/mkdocs.yaml
@@ -35,6 +35,7 @@ extra:
 nav:
   - index: index.md
   - getting-started.md
+  - international.md
   - setup:
       - setup/requirements.md
       - setup/introduction.md
@@ -87,6 +88,7 @@ nav:
       - ml_sample/algorithms.md
       - ml_sample/faq.md
   - FAQ: faq.md
+  - Glossary: glossary.md
   - Community: community.md
   - Contributing: contributing.md
 


### PR DESCRIPTION
## 概要
日本語を読まない参加者のために、2 つのページ（日本語・英語の対）を追加します。

1. **用語集（`glossary.{ja,en}.md`）**: ルール・オンライン環境・Slack に出てくる日本語の用語 25 個（走行枠、反則、BLOCK、ハンディキャップ、マッチメイキング、持参 PC など）と、このサイトの英語版での表記、1 行の説明。ルールに関わる説明はルールページの記述（例: BLOCK は 20 秒間 5 km/h の速度制限）に合わせ、リンク先を正としています。
2. **海外・日本語以外の参加者向けガイド（`international.{ja,en}.md`）**: 最初に読むページの順番、Ubuntu 22.04 などの環境の要点（推奨環境ページの内容）、言葉についてのヒント、質問の仕方（FAQ・Slack の質問チャンネル・Issue）。

- `mkdocs.yaml` の nav に `international.md`（getting-started の次）と `Glossary: glossary.md`（FAQ の次）を追加しました。
- 同じ言語のページへのリンクを使っています。英語版がまだ別 PR（#77・#78・#79）にある 3 ページだけは、サイトの URL にしました（マージ後は自動で英語ページになります）。
- `mkdocs build` の WARNING 数は変わりません（19 件）。markdownlint・prettier・Markdown Link Check を含む pre-commit はすべて通過しています。

用語の選び方や説明に違和感があれば、ご指摘ください。

## Summary
Adds two page pairs (Japanese and English) for participants who do not read Japanese.

1. **Glossary (`glossary.{ja,en}.md`)**: 25 Japanese terms used in the rules, the online environment and Slack (run slot, foul, BLOCK, handicap, matchmaking, bring-your-own PC and more), with the English used on this site and a one-line meaning. Rule-related entries follow the wording of the rules pages (for example, BLOCK is a 20-second 5 km/h speed limit), and the linked rules pages are authoritative.
2. **For International Participants (`international.{ja,en}.md`)**: which pages to read first and in what order, the environment essentials (Ubuntu 22.04 and the rest of the Recommended Environment page), language tips, and where to ask (FAQ, the Slack question channel, issues).

- `mkdocs.yaml` nav: `international.md` after getting-started, and `Glossary: glossary.md` after FAQ.
- Links point at the same-language pages. Only the three pages whose English versions are still in separate PRs (#77, #78, #79) use the site URL, which will show the English page once those merge.
- `mkdocs build` warnings are unchanged (19). pre-commit passes, including markdownlint, prettier and Markdown Link Check.

Corrections to the term choices or definitions are welcome.

---
Team Hayes (Ajayaditya Lokchandra, Nithisha Venkatesh)

本PRはAIコーディング支援を用いて作成し、上記の確認手順で検証しました。 / Prepared with AI coding assistance and verified with the checks above.
